### PR TITLE
feat(tor): hidden-service hosting (publishHiddenService)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Implemented:
 
 - [x] Client circuit to clearweb (3-hop ntor + relay cells)
 - [x] Client circuit to v3 hidden services (rend-spec-v3, INTRODUCE/RENDEZVOUS, hs-ntor)
+- [x] **Hosting v3 hidden services (server side: ESTABLISH_INTRO with KH-bound MAC, descriptor build/sign/publish, INTRODUCE2 decrypt, hs-ntor server, rendezvous virtual hop)**
 - [x] Browser support via Snowflake (WSS → turbotunnel → KCP → SMUX → TLS 1.3 → Tor)
 - [x] Signed-consensus verification (against the hardcoded mainnet authorities; injectable trust anchor for chutney/test nets)
 - [x] Bandwidth-weighted relay selection with exit-policy filtering
@@ -29,16 +30,19 @@ Not implemented:
 
 - [ ] Guard / middle / exit relay (this is a client-only stack)
 - [ ] Directory authority
-- [ ] Hidden service (server side)
 
 ### Packages
 
 - [`packages/tor`](./packages/tor) — the Tor protocol implementation:
   cells, circuits, link/relay protocols, ntor handshake, directory client,
-  consensus parsing+verification, hidden-service client. Standalone in
-  Node.js with a TLS channel; the entry point most users want is
+  consensus parsing+verification, hidden-service client + server. Standalone
+  in Node.js with a TLS channel; the entry point most users want is
   `connectRandomCircuitWithSafeBootstrap()` from
   [`packages/tor/src/build-circuit/mainnet.ts`](./packages/tor/src/build-circuit/mainnet.ts).
+  To host an onion service, the entry point is `publishHiddenService(...)`
+  in [`packages/tor/src/hidden-service-host.ts`](./packages/tor/src/hidden-service-host.ts) —
+  takes any bootstrapped `TorClient` (mainnet, chutney, or browser/Snowflake)
+  and surfaces inbound BEGIN-streams via an `onConnection` callback.
 - [`packages/snowflake`](./packages/snowflake) — the client side of the
   [Snowflake](https://snowflake.torproject.org/) pluggable transport in pure
   TypeScript: encapsulation framing, turbotunnel preamble,

--- a/packages/crypto/src/browser.ts
+++ b/packages/crypto/src/browser.ts
@@ -14,6 +14,10 @@ export * from './curves.ts';
 // Re-export AES stream ciphers (same implementation for Node.js and browser)
 export * from './aes.ts';
 
+// Re-export rend-spec-v3 hidden-service crypto helpers (same impl for both
+// platforms; consumed by the `tor` package's hidden-service client + host).
+export * from './hs-crypto.ts';
+
 // Import sha1 for use in computeRsaKeyFingerprint
 import { sha1 } from './hashes.ts';
 

--- a/packages/crypto/src/hs-crypto.ts
+++ b/packages/crypto/src/hs-crypto.ts
@@ -1,0 +1,137 @@
+/**
+ * Crypto helpers used by the rend-spec-v3 hidden-service client + server
+ * implementations in the `tor` package. Kept here in `tor-crypto` so the
+ * exact same primitives are available to Node.js and browser consumers
+ * (the host needs them server-side, the client needs them everywhere).
+ *
+ * Everything is a thin Buffer-shaped wrapper over `sha3_256` / `shake256`
+ * so it works identically across platforms.
+ */
+
+import { sha3_256, shake256 } from './hashes.ts';
+
+/** SHA3-256 of the concatenation of `parts`. */
+export function sha3(...parts: Buffer[]): Buffer {
+  return Buffer.from(sha3_256(Buffer.concat(parts)));
+}
+
+/** SHAKE256-based KDF emitting `length` bytes. */
+export function kdfShake256(input: Buffer, length: number): Buffer {
+  return Buffer.from(shake256(input, { dkLen: length }));
+}
+
+/** Encode a bigint as 8 big-endian bytes (`htonll`). */
+export function u64be(n: bigint): Buffer {
+  const b = Buffer.alloc(8);
+  b.writeBigUInt64BE(n);
+  return b;
+}
+
+/**
+ * SHA3-256 MAC per rend-spec-v3 §0.3:
+ * `SHA3_256(htonll(len(k)) || k || m)`.
+ */
+export function mac(key: Buffer, message: Buffer): Buffer {
+  return sha3(u64be(BigInt(key.length)), key, message);
+}
+
+/**
+ * Domain-separated MAC for descriptor layers (rend-spec-v3 §2.5.1.1):
+ * `SHA3_256(htonll(len(macKey)) || macKey || htonll(len(salt)) || salt || encrypted)`.
+ */
+export function dMac(macKey: Buffer, salt: Buffer, encrypted: Buffer): Buffer {
+  return sha3(u64be(BigInt(macKey.length)), macKey, u64be(BigInt(salt.length)), salt, encrypted);
+}
+
+/** Decode a little-endian byte buffer as a non-negative bigint. */
+export function bytesToBigIntLE(bytes: Uint8Array): bigint {
+  let n = 0n;
+  for (let i = bytes.length - 1; i >= 0; i--) {
+    n = (n << 8n) | BigInt(bytes[i] ?? 0);
+  }
+  return n;
+}
+
+/** Encode a non-negative bigint as `length` little-endian bytes. */
+export function bigIntToBytesLE(n: bigint, length: number): Buffer {
+  const out = Buffer.alloc(length);
+  let temp = n;
+  for (let i = 0; i < length; i++) {
+    out[i] = Number(temp & 0xffn);
+    temp >>= 8n;
+  }
+  return out;
+}
+
+/**
+ * Modular inverse `a^-1 mod p` via Fermat's little theorem.
+ * `p` must be prime; used for the curve25519→ed25519 conversion.
+ */
+export function modInverse(a: bigint, p: bigint): bigint {
+  let result = 1n;
+  let base = ((a % p) + p) % p;
+  let exp = p - 2n;
+  while (exp > 0n) {
+    if (exp & 1n) result = (result * base) % p;
+    base = (base * base) % p;
+    exp >>= 1n;
+  }
+  return result;
+}
+
+/**
+ * Streaming SHA3-256 hash with copy semantics, structurally compatible with
+ * the `CopyableHash` interface in the `tor` package's circuit module
+ * (`{ update(); copy(); digest(); }`). Browser-compatible — no `node:crypto`.
+ *
+ * IMPORTANT: `update()` copies its input — relay-cell digest computation
+ * sets the integrity field after updating, so the original Buffer would
+ * otherwise mutate under the digest.
+ */
+export class Sha3_256Hash {
+  private accumulated: Uint8Array[] = [];
+
+  update(data: Buffer | Uint8Array): this {
+    this.accumulated.push(Uint8Array.from(data));
+    return this;
+  }
+
+  copy(): Sha3_256Hash {
+    const cloned = new Sha3_256Hash();
+    cloned.accumulated = [...this.accumulated];
+    return cloned;
+  }
+
+  digest(): Buffer {
+    const totalLength = this.accumulated.reduce((sum, arr) => sum + arr.length, 0);
+    const combined = new Uint8Array(totalLength);
+    let offset = 0;
+    for (const arr of this.accumulated) {
+      combined.set(arr, offset);
+      offset += arr.length;
+    }
+    return Buffer.from(sha3_256(combined));
+  }
+}
+
+export function createSha3_256Hash(): Sha3_256Hash {
+  return new Sha3_256Hash();
+}
+
+/** RFC4648 base32 alphabet, lowercase, unpadded. */
+export function base32EncodeLowerNoPad(buf: Buffer): string {
+  const alphabet = 'abcdefghijklmnopqrstuvwxyz234567';
+  let bits = 0;
+  let value = 0;
+  let out = '';
+  for (let i = 0; i < buf.length; i++) {
+    value = (value << 8) | (buf[i] ?? 0);
+    bits += 8;
+    while (bits >= 5) {
+      out += alphabet[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) out += alphabet[(value << (5 - bits)) & 31];
+  return out;
+}

--- a/packages/crypto/src/node.ts
+++ b/packages/crypto/src/node.ts
@@ -17,6 +17,10 @@ export * from './curves.ts';
 // Re-export AES stream ciphers (same implementation for Node.js and browser)
 export * from './aes.ts';
 
+// Re-export rend-spec-v3 hidden-service crypto helpers (same impl for both
+// platforms; consumed by the `tor` package's hidden-service client + host).
+export * from './hs-crypto.ts';
+
 // Import sha1 for use in computeRsaKeyFingerprint
 import { sha1 } from './hashes.ts';
 

--- a/packages/tor/package.json
+++ b/packages/tor/package.json
@@ -30,6 +30,7 @@
     "./build-circuit/util": "./src/build-circuit/util.ts",
     "./cli": "./src/cli.ts",
     "./hidden-service": "./src/hidden-service.ts",
+    "./hidden-service-host": "./src/hidden-service-host.ts",
     "./relay-cell": "./src/relay-cell.ts"
   },
   "scripts": {

--- a/packages/tor/scripts/chutney-hidden-service-host-ci.ts
+++ b/packages/tor/scripts/chutney-hidden-service-host-ci.ts
@@ -1,0 +1,197 @@
+/**
+ * Chutney integration test for hidden-service hosting.
+ *
+ * Publishes a v3 onion service via {@link publishHiddenService} on the local
+ * chutney network, then connects to it as a client through
+ * {@link makeChutneyTorClient} and asserts an HTTP exchange round-trips.
+ *
+ * The host's `onConnection` callback hands us each accepted incoming stream
+ * (one per BEGIN cell). We run a minimal HTTP responder per stream — enough
+ * to verify the full INTRODUCE1 → INTRODUCE2 → RENDEZVOUS1 → RENDEZVOUS2 →
+ * BEGIN → DATA → END pipeline.
+ *
+ * Gated via `TOR_TS_CHUTNEY_TESTS` including `hidden-service-host`; OFF by
+ * default in `ci-chutney.sh` because it exercises the full HS protocol stack
+ * end-to-end and is the most fragile test in the suite.
+ */
+
+import type { CircuitStream } from '../src/circuit.ts';
+import { publishHiddenService } from '../src/hidden-service-host.ts';
+import { makeChutneyTorClient } from '../src/build-circuit/chutney.ts';
+
+const HS_VIRTUAL_PORT = 80;
+const EXPECTED_BODY = 'hello-from-tor-ts-hidden-service-host';
+
+async function withTimeout<T>(label: string, ms: number, p: Promise<T>): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeoutP = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+  });
+  try {
+    return await Promise.race([p, timeoutP]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/** Minimal HTTP/1.1 responder per accepted stream. */
+function attachHttpResponder(stream: CircuitStream, log: (msg: string) => void): void {
+  let answered = false;
+  stream.on('data', (data: Buffer) => {
+    if (answered) return;
+    answered = true;
+    log(`responder: ${data.length}B request on stream=${stream.streamId}`);
+    const body = EXPECTED_BODY;
+    const response = Buffer.from(
+      `HTTP/1.1 200 OK\r\n` +
+        `Content-Type: text/plain\r\n` +
+        `Content-Length: ${body.length}\r\n` +
+        `Connection: close\r\n` +
+        `\r\n` +
+        body,
+      'utf8'
+    );
+    stream.write(response).catch((err) => log(`write failed: ${err}`));
+    // Best-effort: tear down the stream so the client sees END.
+    setTimeout(() => stream.destroy(), 50);
+  });
+}
+
+async function main(): Promise<void> {
+  const log = (msg: string) => console.log(`[hs-host-ci] ${msg}`);
+
+  const overallTimeoutMs = 10 * 60_000;
+  const perStepTimeoutMs = 120_000;
+
+  log('bootstrapping host TorClient...');
+  const hostClient = await withTimeout(
+    'makeChutneyTorClient (host)',
+    overallTimeoutMs,
+    makeChutneyTorClient({ onStatus: (m) => log(`host-client: ${m}`) })
+  );
+
+  let host: Awaited<ReturnType<typeof publishHiddenService>> | undefined;
+  let visitorClient: Awaited<ReturnType<typeof makeChutneyTorClient>> | undefined;
+  try {
+    log('publishing hidden service...');
+    host = await withTimeout(
+      'publishHiddenService',
+      overallTimeoutMs,
+      publishHiddenService({
+        torClient: hostClient,
+        port: HS_VIRTUAL_PORT,
+        onConnection: (stream) => {
+          log(`onConnection: stream=${stream.streamId} dest=${stream.destination}`);
+          attachHttpResponder(stream, log);
+        },
+        numIntroPoints: 2,
+        perStepTimeoutMs,
+        log: (m) => log(`host: ${m}`),
+      })
+    );
+    log(`onion address: ${host.onion}`);
+    log(`active intro points: ${host.numActiveIntroPoints()}`);
+
+    log('waiting 10s for descriptor propagation...');
+    await new Promise((r) => setTimeout(r, 10_000));
+
+    log('bootstrapping visitor TorClient...');
+    visitorClient = await withTimeout(
+      'makeChutneyTorClient (visitor)',
+      overallTimeoutMs,
+      makeChutneyTorClient({ onStatus: (m) => log(`visitor-client: ${m}`) })
+    );
+
+    log('connecting to hidden service...');
+    const { circuit } = await withTimeout(
+      'connectToHiddenService',
+      overallTimeoutMs,
+      visitorClient.connectToHiddenService(host.onion, HS_VIRTUAL_PORT, {
+        overallTimeoutMs: perStepTimeoutMs,
+      })
+    );
+    log('connected; opening application stream');
+
+    const stream = await withTimeout(
+      'open stream',
+      30_000,
+      circuit.open(`${host.onion}:${HS_VIRTUAL_PORT}`)
+    );
+
+    const chunks: Buffer[] = [];
+    stream.on('data', (d: Buffer) => chunks.push(Buffer.from(d)));
+
+    const completeP = (async () => {
+      const start = Date.now();
+      while (Date.now() - start < overallTimeoutMs) {
+        const buf = Buffer.concat(chunks);
+        const headerEnd = buf.indexOf('\r\n\r\n');
+        if (headerEnd !== -1) {
+          const headers = buf.subarray(0, headerEnd).toString('utf8');
+          const m = headers.match(/\r?\ncontent-length:\s*(\d+)\s*\r?\n/i);
+          if (m?.[1]) {
+            const cl = Number.parseInt(m[1], 10);
+            if (buf.length >= headerEnd + 4 + cl) return;
+          }
+        }
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      throw new Error('Timed out waiting for HTTP response from hidden service');
+    })();
+
+    log('sending HTTP GET');
+    const requestText =
+      `GET / HTTP/1.1\r\n` +
+      `Host: ${host.onion}\r\n` +
+      `Connection: close\r\n` +
+      `\r\n`;
+    await withTimeout(
+      'write request',
+      perStepTimeoutMs,
+      stream.write(Buffer.from(requestText, 'ascii'))
+    );
+
+    await withTimeout('await response', overallTimeoutMs, completeP);
+    const responseText = Buffer.concat(chunks).toString('utf8');
+    log(`response head: ${responseText.split('\r\n')[0] ?? '(none)'}`);
+
+    if (!responseText.includes(' 200 ')) {
+      throw new Error(`Expected HTTP 200, got:\n${responseText.slice(0, 400)}`);
+    }
+    if (!responseText.includes(EXPECTED_BODY)) {
+      throw new Error(`Expected body "${EXPECTED_BODY}" in response, got:\n${responseText}`);
+    }
+
+    log('PASS — hidden service hosted + reachable end-to-end via chutney');
+
+    stream.destroy();
+    circuit.destroy();
+  } finally {
+    if (host) await host.unpublish();
+    if (visitorClient) {
+      try {
+        visitorClient.destroy();
+      } catch {
+        // best-effort
+      }
+    }
+    try {
+      hostClient.destroy();
+    } catch {
+      // best-effort
+    }
+  }
+}
+
+main().then(
+  () => {
+    // Same reason as chutney-hidden-service-ci.ts: channel-padding timers
+    // and TLS sockets keep the event loop alive. Force-exit so CI's outer
+    // `timeout` doesn't have to.
+    process.exit(0);
+  },
+  (err) => {
+    console.error('hs-host CI failed:', err);
+    process.exit(1);
+  }
+);

--- a/packages/tor/scripts/chutney-hidden-service-host-ci.ts
+++ b/packages/tor/scripts/chutney-hidden-service-host-ci.ts
@@ -10,9 +10,10 @@
  * to verify the full INTRODUCE1 → INTRODUCE2 → RENDEZVOUS1 → RENDEZVOUS2 →
  * BEGIN → DATA → END pipeline.
  *
- * Gated via `TOR_TS_CHUTNEY_TESTS` including `hidden-service-host`; OFF by
- * default in `ci-chutney.sh` because it exercises the full HS protocol stack
- * end-to-end and is the most fragile test in the suite.
+ * Runs when `TOR_TS_CHUTNEY_TESTS` includes `hidden-service-host` (the
+ * current default in `ci-chutney.sh` is `exit,hidden-service,hidden-service-host`).
+ * It exercises the full HS protocol stack end-to-end and is one of the more
+ * fragile tests in the suite.
  */
 
 import type { CircuitStream } from '../src/circuit.ts';

--- a/packages/tor/scripts/chutney-hidden-service-host-ci.ts
+++ b/packages/tor/scripts/chutney-hidden-service-host-ci.ts
@@ -141,10 +141,7 @@ async function main(): Promise<void> {
 
     log('sending HTTP GET');
     const requestText =
-      `GET / HTTP/1.1\r\n` +
-      `Host: ${host.onion}\r\n` +
-      `Connection: close\r\n` +
-      `\r\n`;
+      `GET / HTTP/1.1\r\n` + `Host: ${host.onion}\r\n` + `Connection: close\r\n` + `\r\n`;
     await withTimeout(
       'write request',
       perStepTimeoutMs,

--- a/packages/tor/scripts/ci-chutney.sh
+++ b/packages/tor/scripts/ci-chutney.sh
@@ -223,7 +223,7 @@ cd "${ROOT_DIR}"
 # on the rendezvous point in microDescNodeInfoToPeerInfo (fixed in the
 # same PR, with spec-vector and unit tests in hidden-service-test-vector
 # .spec.ts + directory.spec.ts).
-TOR_TS_CHUTNEY_TESTS="${TOR_TS_CHUTNEY_TESTS:-exit,hidden-service}"
+TOR_TS_CHUTNEY_TESTS="${TOR_TS_CHUTNEY_TESTS:-exit,hidden-service,hidden-service-host}"
 IFS=',' read -ra TESTS <<< "${TOR_TS_CHUTNEY_TESTS}"
 for t in "${TESTS[@]}"; do
   case "${t}" in
@@ -239,13 +239,13 @@ for t in "${TESTS[@]}"; do
       echo "=== chutney integration test: hidden-service finished at $(date -Is) ==="
       ;;
     hidden-service-host)
-      # Opt-in: hosts a v3 HS via our HiddenServiceHost and connects to it
-      # with our client. Exercises the entire HS protocol stack end-to-end
-      # (descriptor publish + INTRODUCE2 + RENDEZVOUS1 + virtual hop) so it
-      # is the most fragile test in the suite. Set TOR_TS_CHUTNEY_TESTS to
-      # include "hidden-service-host" to enable.
+      # Hosts a v3 HS via publishHiddenService() and connects to it with our
+      # client. Exercises the entire HS protocol stack end-to-end (descriptor
+      # publish + INTRODUCE2 + RENDEZVOUS1 + virtual hop + BEGIN/DATA on the
+      # rendezvous circuit). Most fragile test in the suite — first to flake
+      # if the HS protocol path regresses.
       echo ""
-      echo "=== running chutney integration test: hidden-service-host (opt-in) ==="
+      echo "=== running chutney integration test: hidden-service-host ==="
       timeout 12m node --experimental-transform-types "${ROOT_DIR}/scripts/chutney-hidden-service-host-ci.ts"
       echo "=== chutney integration test: hidden-service-host finished at $(date -Is) ==="
       ;;

--- a/packages/tor/scripts/ci-chutney.sh
+++ b/packages/tor/scripts/ci-chutney.sh
@@ -238,6 +238,17 @@ for t in "${TESTS[@]}"; do
       timeout 10m node --experimental-transform-types "${ROOT_DIR}/scripts/chutney-hidden-service-ci.ts"
       echo "=== chutney integration test: hidden-service finished at $(date -Is) ==="
       ;;
+    hidden-service-host)
+      # Opt-in: hosts a v3 HS via our HiddenServiceHost and connects to it
+      # with our client. Exercises the entire HS protocol stack end-to-end
+      # (descriptor publish + INTRODUCE2 + RENDEZVOUS1 + virtual hop) so it
+      # is the most fragile test in the suite. Set TOR_TS_CHUTNEY_TESTS to
+      # include "hidden-service-host" to enable.
+      echo ""
+      echo "=== running chutney integration test: hidden-service-host (opt-in) ==="
+      timeout 12m node --experimental-transform-types "${ROOT_DIR}/scripts/chutney-hidden-service-host-ci.ts"
+      echo "=== chutney integration test: hidden-service-host finished at $(date -Is) ==="
+      ;;
     *)
       echo "Unknown TOR_TS_CHUTNEY_TESTS entry: ${t}"
       exit 1

--- a/packages/tor/src/circuit.ts
+++ b/packages/tor/src/circuit.ts
@@ -175,6 +175,13 @@ class Hop {
   ntorEphemeralKeyPublic!: Buffer;
   createFastX?: Buffer;
 
+  /**
+   * The ntor KH for this hop — the 20-byte DIGEST_LEN nonce derived from the
+   * ntor handshake KDF, used as the MAC_KEY for ESTABLISH_INTRO HANDSHAKE_AUTH
+   * (rend-spec-v3 §3.1.1.2 / tor-spec.txt §5.2.2). Only set for ntor hops.
+   */
+  ntorKh?: Buffer;
+
   async encryptForward(data: Buffer) {
     return Buffer.from(await this.cipherPair.forward.key.encrypt(data));
   }
@@ -293,8 +300,13 @@ class Hop {
       serverNtorEphemeralKeyPublic,
       serverNtorAuth,
     });
-    const keyMaterial = KDF_RFC5869(keySeed, 2 * HASH_LEN + 2 * KEY_LEN);
+    // Per tor-spec.txt §5.2.2 the ntor KDF emits Df, Db, Kf, Kb followed by a
+    // DIGEST_LEN trailing nonce that takes the place of KH for the hidden
+    // service protocol. We always derive it so HiddenServiceHost can use it
+    // as the MAC_KEY for ESTABLISH_INTRO HANDSHAKE_AUTH.
+    const keyMaterial = KDF_RFC5869(keySeed, 2 * HASH_LEN + 2 * KEY_LEN + HASH_LEN);
     this.cipherPair = makeTor1CipherPairFromKeyMaterial(keyMaterial);
+    this.ntorKh = Buffer.from(keyMaterial.subarray(2 * HASH_LEN + 2 * KEY_LEN));
     this.isConnected = true;
     this.handshakeLatch.resolve();
   }
@@ -598,6 +610,22 @@ export class Circuit extends EventEmitter {
       throw new Error('Circuit has no hops');
     }
     return hop;
+  }
+
+  /**
+   * Return the last hop's ntor KH — the 20-byte trailing nonce from the
+   * ntor KDF, used as the MAC_KEY for the ESTABLISH_INTRO HANDSHAKE_AUTH
+   * field (rend-spec-v3 §3.1.1.2). Throws if the last hop was built with
+   * CREATE_FAST or hasn't completed an ntor handshake yet.
+   */
+  getLastHopNtorKh(): Buffer {
+    const kh = this.lastHop.ntorKh;
+    if (!kh) {
+      throw new Error(
+        'Last hop has no ntorKh — circuit was built with CREATE_FAST or handshake incomplete'
+      );
+    }
+    return kh;
   }
 
   /**

--- a/packages/tor/src/client.ts
+++ b/packages/tor/src/client.ts
@@ -5,7 +5,7 @@
  * Platform-specific factories create instances with appropriate dependencies.
  */
 
-import { Circuit } from './circuit.ts';
+import { Circuit, type PeerInfo } from './circuit.ts';
 import type { VerifiedMicroDescConsensus } from './build-circuit/directory.ts';
 import type { IntroPoint, BuildCircuitFn } from './hidden-service.ts';
 import { connectToHiddenServiceCore } from './hidden-service.ts';
@@ -205,6 +205,26 @@ export class TorClient<TChannel extends ChannelConnection = ChannelConnection> {
   async buildCircuit(options: { targetPorts?: number[] } = {}): Promise<CircuitResult> {
     this.checkDestroyed();
     return this.buildCircuitFn(options);
+  }
+
+  /**
+   * Build a 3-hop circuit terminating at `target`. Used by the hidden-service
+   * host for intro/RP/HSDir circuits, and reachable from anywhere a
+   * platform-specific {@link TorClient} has been wired (mainnet, chutney, or
+   * Snowflake-backed browser client).
+   */
+  async buildCircuitToTarget(
+    target: PeerInfo,
+    options: { avoid?: PeerInfo[] } = {}
+  ): Promise<Circuit> {
+    this.checkDestroyed();
+    return this.buildCircuitToTargetFn(target, options);
+  }
+
+  /** Public read-only access for HS-host descriptor publishing. */
+  get bootstrapDirCircuit(): Circuit {
+    this.checkDestroyed();
+    return this.bootstrapCircuit;
   }
 
   async refreshConsensus(): Promise<VerifiedMicroDescConsensus> {

--- a/packages/tor/src/hidden-service-host.spec.ts
+++ b/packages/tor/src/hidden-service-host.spec.ts
@@ -1,0 +1,540 @@
+import test from 'ava';
+import { x25519, ed25519, randomBytes, ed25519VerifySync } from 'tor-crypto';
+import * as ed from '@noble/ed25519';
+
+import {
+  generateHiddenServiceKeys,
+  loadHiddenServiceKeys,
+  computeOnionAddress,
+  deriveBlindedPrivateKey,
+  signWithBlindedKey,
+  deriveTimePeriodKeys,
+  generateIntroPointKeys,
+  buildEstablishIntroPayload,
+  parseIntroduce2,
+  decryptIntroduce2,
+  completeHsNtorServer,
+  generateDescriptor,
+  // private re-exports for primitive tests
+  sha3,
+  mac,
+  dMac,
+  kdfShake256,
+  base32EncodeLowerNoPad,
+  curve25519PubkeyToEd25519,
+  encryptDescriptorLayer,
+  createEd25519Certificate,
+  type IntroductionPoint,
+} from './hidden-service-host.ts';
+import {
+  parseOnionV3Address,
+  deriveBlindedPublicKey,
+  deriveSubcredential,
+  hsNtorDeriveEncAndMac,
+  hsNtorComplete,
+  buildIntroduce1Payload,
+  makeHsRendezvousCipherPairFromKeySeed,
+} from './hidden-service.ts';
+import { LinkSpecifierTypes } from './messaging.ts';
+import type { PeerInfo } from './circuit.ts';
+
+function makePeerInfo(seed = 0): PeerInfo {
+  const _ = seed;
+  return {
+    onionKey: Buffer.from(x25519.utils.randomPrivateKey()),
+    rsaIdDigest: Buffer.from(randomBytes(20)),
+    linkSpecifiers: [
+      { type: LinkSpecifierTypes.TlsOverTcpIPv4, data: Buffer.from([127, 0, 0, 1, 0x1f, 0x90]) },
+      { type: LinkSpecifierTypes.LegacyId, data: Buffer.from(randomBytes(20)) },
+    ],
+  };
+}
+
+// =============================================================================
+// Key generation + onion address
+// =============================================================================
+
+test('generateHiddenServiceKeys produces 32-byte ed25519 keypair + 56-char onion base', (t) => {
+  const keys = generateHiddenServiceKeys();
+  t.is(keys.identityPrivateKey.length, 32);
+  t.is(keys.identityPublicKey.length, 32);
+  t.is(keys.onionAddressBase.length, 56);
+  t.is(keys.onionAddress, `${keys.onionAddressBase}.onion`);
+});
+
+test('generateHiddenServiceKeys produces unique identities', (t) => {
+  const a = generateHiddenServiceKeys();
+  const b = generateHiddenServiceKeys();
+  t.false(a.identityPrivateKey.equals(b.identityPrivateKey));
+  t.not(a.onionAddress, b.onionAddress);
+});
+
+test('loadHiddenServiceKeys recovers the same address from the seed', (t) => {
+  const original = generateHiddenServiceKeys();
+  const loaded = loadHiddenServiceKeys(original.identityPrivateKey);
+  t.deepEqual(loaded.identityPublicKey, original.identityPublicKey);
+  t.is(loaded.onionAddress, original.onionAddress);
+});
+
+test('loadHiddenServiceKeys rejects wrong-sized seeds', (t) => {
+  t.throws(() => loadHiddenServiceKeys(Buffer.alloc(31)), { message: /32 bytes/ });
+});
+
+test('computeOnionAddress matches the round-trip via parseOnionV3Address', (t) => {
+  const keys = generateHiddenServiceKeys();
+  const addr = computeOnionAddress(keys.identityPublicKey);
+  t.is(addr, keys.onionAddress);
+  const { publicIdentityKey } = parseOnionV3Address(addr);
+  t.deepEqual(publicIdentityKey, keys.identityPublicKey);
+});
+
+// =============================================================================
+// Blinded key derivation + EdDSA signing
+// =============================================================================
+
+test('deriveBlindedPrivateKey: server blinded public key matches client derivation', (t) => {
+  const keys = generateHiddenServiceKeys();
+  const periodNum = 1234n;
+  const periodLengthMinutes = 1440n;
+
+  const { blindedPublicKey } = deriveBlindedPrivateKey({
+    identityPrivateKey: keys.identityPrivateKey,
+    periodNum,
+    periodLengthMinutes,
+  });
+  const clientBlinded = deriveBlindedPublicKey({
+    publicIdentityKey: keys.identityPublicKey,
+    periodNum,
+    periodLengthMinutes,
+  });
+  t.deepEqual(blindedPublicKey, clientBlinded);
+});
+
+test('deriveBlindedPrivateKey: different periods produce different keys', (t) => {
+  const keys = generateHiddenServiceKeys();
+  const a = deriveBlindedPrivateKey({
+    identityPrivateKey: keys.identityPrivateKey,
+    periodNum: 1000n,
+    periodLengthMinutes: 1440n,
+  });
+  const b = deriveBlindedPrivateKey({
+    identityPrivateKey: keys.identityPrivateKey,
+    periodNum: 1001n,
+    periodLengthMinutes: 1440n,
+  });
+  t.false(a.blindedPrivateKey.equals(b.blindedPrivateKey));
+  t.false(a.blindedPublicKey.equals(b.blindedPublicKey));
+});
+
+test('signWithBlindedKey: signature verifies under the blinded public key', (t) => {
+  const keys = generateHiddenServiceKeys();
+  const { blindedPublicKey, blindedSigningKey } = deriveBlindedPrivateKey({
+    identityPrivateKey: keys.identityPrivateKey,
+    periodNum: 42n,
+    periodLengthMinutes: 1440n,
+  });
+  const msg = Buffer.from('a descriptor signing key cert body or whatever', 'ascii');
+  const sig = signWithBlindedKey(msg, blindedSigningKey, blindedPublicKey);
+  t.is(sig.length, 64);
+  t.true(ed25519VerifySync(sig, msg, blindedPublicKey));
+});
+
+test('signWithBlindedKey: rejects 32-byte blinded private key (must be expanded form)', (t) => {
+  const keys = generateHiddenServiceKeys();
+  const { blindedPrivateKey, blindedPublicKey } = deriveBlindedPrivateKey({
+    identityPrivateKey: keys.identityPrivateKey,
+    periodNum: 1n,
+    periodLengthMinutes: 1440n,
+  });
+  t.throws(
+    () => signWithBlindedKey(Buffer.from('msg'), blindedPrivateKey, blindedPublicKey),
+    { message: /64 bytes/ }
+  );
+});
+
+test('deriveTimePeriodKeys: subcredential matches client deriveSubcredential', (t) => {
+  const keys = generateHiddenServiceKeys();
+  const validAfter = new Date('2025-01-12T00:00:00Z');
+  const freshUntil = new Date('2025-01-12T01:00:00Z');
+  const tp = deriveTimePeriodKeys({ keys, validAfter, freshUntil });
+  const expected = deriveSubcredential({
+    publicIdentityKey: keys.identityPublicKey,
+    blindedPublicKey: tp.blindedPublicKey,
+  });
+  t.deepEqual(tp.subcredential, expected);
+});
+
+test('deriveTimePeriodKeys: emits both 32-byte private + 64-byte signing key', (t) => {
+  const keys = generateHiddenServiceKeys();
+  const tp = deriveTimePeriodKeys({ keys, validAfter: new Date() });
+  t.is(tp.blindedPrivateKey.length, 32);
+  t.is(tp.blindedSigningKey.length, 64);
+  // The first 32 bytes of the signing key are the canonical scalar.
+  t.deepEqual(tp.blindedSigningKey.subarray(0, 32), tp.blindedPrivateKey);
+});
+
+// =============================================================================
+// Crypto primitives (sanity)
+// =============================================================================
+
+test('sha3 is deterministic and 32 bytes', (t) => {
+  const a = sha3(Buffer.from('hello'));
+  const b = sha3(Buffer.from('hello'));
+  t.is(a.length, 32);
+  t.deepEqual(a, b);
+});
+
+test('mac vs dMac produce different outputs (different domain separation)', (t) => {
+  const k = Buffer.from('a key');
+  const m = Buffer.from('a message');
+  const macOut = mac(k, m);
+  const dMacOut = dMac(k, Buffer.from('salt'), m);
+  t.is(macOut.length, 32);
+  t.is(dMacOut.length, 32);
+  t.false(macOut.equals(dMacOut));
+});
+
+test('kdfShake256 honors requested length', (t) => {
+  const out = kdfShake256(Buffer.from('seed'), 80);
+  t.is(out.length, 80);
+});
+
+test('base32EncodeLowerNoPad is lowercase + unpadded', (t) => {
+  const out = base32EncodeLowerNoPad(Buffer.from('Hello'));
+  t.is(out, out.toLowerCase());
+  t.false(out.includes('='));
+});
+
+// =============================================================================
+// curve25519 -> ed25519 (proposal 228 appendix A)
+// =============================================================================
+
+test('curve25519PubkeyToEd25519: deterministic, 32 bytes, sign bit clear', (t) => {
+  const u = Buffer.from(x25519.utils.randomPrivateKey());
+  const pub = Buffer.from(x25519.getPublicKey(u));
+  const ed = curve25519PubkeyToEd25519(pub);
+  const ed2 = curve25519PubkeyToEd25519(pub);
+  t.is(ed.length, 32);
+  t.deepEqual(ed, ed2);
+  t.is((ed[31] ?? 0) & 0x80, 0); // sign bit forced to 0
+});
+
+test('curve25519PubkeyToEd25519: distinct inputs map to distinct outputs', (t) => {
+  const a = Buffer.from(x25519.getPublicKey(x25519.utils.randomPrivateKey()));
+  const b = Buffer.from(x25519.getPublicKey(x25519.utils.randomPrivateKey()));
+  t.notDeepEqual(curve25519PubkeyToEd25519(a), curve25519PubkeyToEd25519(b));
+});
+
+test('curve25519PubkeyToEd25519: rejects non-32-byte input', (t) => {
+  t.throws(() => curve25519PubkeyToEd25519(Buffer.alloc(31)), { message: /32 bytes/ });
+});
+
+// =============================================================================
+// ESTABLISH_INTRO byte format + signature
+// =============================================================================
+
+test('buildEstablishIntroPayload: byte layout matches rend-spec-v3 §3.1.1', (t) => {
+  const authKeyPrivate = Buffer.from(ed25519.utils.randomPrivateKey());
+  const authKeyPublic = Buffer.from(ed25519.getPublicKey(authKeyPrivate));
+  const circuitMacKey = Buffer.from(randomBytes(20)); // 20-byte ntor KH
+
+  const payload = buildEstablishIntroPayload({
+    authKeyPublic,
+    authKeyPrivate,
+    circuitMacKey,
+  });
+
+  // Layout: AUTH_KEY_TYPE(1) || AUTH_KEY_LEN(2) || AUTH_KEY(32) || N_EXT(1)
+  //      || HANDSHAKE_AUTH(32) || SIG_LEN(2) || SIG(64) = 134 bytes
+  t.is(payload.length, 1 + 2 + 32 + 1 + 32 + 2 + 64);
+  t.is(payload[0], 0x02); // AUTH_KEY_TYPE = ed25519
+  t.is(payload.readUInt16BE(1), 32);
+  t.deepEqual(payload.subarray(3, 35), authKeyPublic);
+  t.is(payload[35], 0); // N_EXT
+  // SIG_LEN at offset 1+2+32+1+32 = 68
+  t.is(payload.readUInt16BE(68), 64);
+});
+
+test('buildEstablishIntroPayload: SIG verifies over "Tor establish-intro cell v1" || body || HANDSHAKE_AUTH', (t) => {
+  const authKeyPrivate = Buffer.from(ed25519.utils.randomPrivateKey());
+  const authKeyPublic = Buffer.from(ed25519.getPublicKey(authKeyPrivate));
+  const circuitMacKey = Buffer.from(randomBytes(20));
+
+  const payload = buildEstablishIntroPayload({
+    authKeyPublic,
+    authKeyPrivate,
+    circuitMacKey,
+  });
+
+  const body = payload.subarray(0, 36); // through N_EXT
+  const handshakeAuth = payload.subarray(36, 68);
+  const sig = payload.subarray(70); // skip SIG_LEN
+
+  const signedInput = Buffer.concat([
+    Buffer.from('Tor establish-intro cell v1', 'ascii'),
+    body,
+    handshakeAuth,
+  ]);
+  t.true(ed25519VerifySync(sig, signedInput, authKeyPublic));
+});
+
+// =============================================================================
+// Ed25519 certificate
+// =============================================================================
+
+test('createEd25519Certificate: produces well-formed cert with signing-key extension', (t) => {
+  const sk = Buffer.from(ed25519.utils.randomPrivateKey());
+  const pk = Buffer.from(ed25519.getPublicKey(sk));
+  const certifiedKey = Buffer.from(randomBytes(32));
+
+  const cert = createEd25519Certificate({
+    certType: 0x09,
+    expirationHours: 100000,
+    certifiedKey,
+    certifiedKeyType: 0x01,
+    signingKey: pk,
+    includeSigningKeyExtension: true,
+    signFn: (msg) => Buffer.from(ed.sign(msg, sk)),
+  });
+  // Body: VERSION(1) + CERT_TYPE(1) + EXPIRATION(4) + KEY_TYPE(1) + KEY(32) + N_EXT(1) + ext(4+32) + SIG(64)
+  t.is(cert.length, 1 + 1 + 4 + 1 + 32 + 1 + (4 + 32) + 64);
+  t.is(cert[0], 0x01);
+  t.is(cert[1], 0x09);
+  t.deepEqual(cert.subarray(7, 39), certifiedKey);
+});
+
+// =============================================================================
+// Descriptor encryption + parse round-trip
+// =============================================================================
+
+test('encryptDescriptorLayer: pads to multiple of 10000 bytes + emits MAC tail', async (t) => {
+  const enc = await encryptDescriptorLayer({
+    plaintext: Buffer.from('hi'),
+    secretData: Buffer.from(randomBytes(32)),
+    subcredential: Buffer.from(randomBytes(32)),
+    revisionCounter: 1n,
+    stringConstant: 'hsdir-encrypted-data',
+  });
+  // salt(16) + ciphertext(>=10000, padded) + mac(32)
+  t.is(enc.length, 16 + 10000 + 32);
+});
+
+test('generateDescriptor: produces a parseable v3 descriptor with required fields', async (t) => {
+  const keys = generateHiddenServiceKeys();
+  const tp = deriveTimePeriodKeys({ keys, validAfter: new Date() });
+  const intro: IntroductionPoint = generateIntroPointKeys(makePeerInfo(), Buffer.from(randomBytes(32)));
+
+  const descriptor = await generateDescriptor({
+    keys,
+    timePeriodKeys: tp,
+    introPoints: [intro],
+    revisionCounter: 7n,
+  });
+
+  t.true(descriptor.startsWith('hs-descriptor 3\n'));
+  t.true(descriptor.includes('descriptor-lifetime 180'));
+  t.true(descriptor.includes('descriptor-signing-key-cert'));
+  t.true(descriptor.includes('revision-counter 7'));
+  t.true(descriptor.includes('superencrypted'));
+  t.true(descriptor.includes('-----BEGIN MESSAGE-----'));
+  t.true(descriptor.includes('-----END MESSAGE-----'));
+  t.true(descriptor.includes('\nsignature '));
+});
+
+// =============================================================================
+// INTRODUCE2: client INTRODUCE1 -> server parse + decrypt round-trip
+// =============================================================================
+
+test('decryptIntroduce2 round-trips against the client buildIntroduce1Payload', async (t) => {
+  // Fix a deterministic-ish setup
+  const keys = generateHiddenServiceKeys();
+  const tp = deriveTimePeriodKeys({ keys, validAfter: new Date() });
+  const intro = generateIntroPointKeys(makePeerInfo(), Buffer.from(randomBytes(32)));
+
+  // Client builds an INTRODUCE1 to this intro point. The 20-byte cookie and
+  // a real rendezvous-point PeerInfo are required.
+  const rendezvousPoint = makePeerInfo();
+  const rendezvousCookie = Buffer.from(randomBytes(20));
+  const { payload } = await buildIntroduce1Payload({
+    introAuthKeyEd25519: intro.authKeyPublic,
+    serviceEncKey: intro.encKeyPublic,
+    N_hs_subcred: tp.subcredential,
+    rendezvousCookie,
+    rendezvousPoint,
+  });
+
+  // INTRODUCE1 and INTRODUCE2 share the same payload bytes (the IP just
+  // forwards them to the service).
+  const parsed = parseIntroduce2(payload);
+  t.deepEqual(parsed.authKey, intro.authKeyPublic);
+
+  const decrypted = await decryptIntroduce2({
+    parsed,
+    introPoint: intro,
+    subcredential: tp.subcredential,
+  });
+
+  t.deepEqual(decrypted.rendezvousCookie, rendezvousCookie);
+  // RP link specifiers should round-trip as-is.
+  t.is(decrypted.linkSpecifiers.length, rendezvousPoint.linkSpecifiers.length);
+});
+
+test('parseIntroduce2 rejects non-ed25519 auth key type', (t) => {
+  // 20 zero bytes (legacy id) + bad type
+  const bad = Buffer.concat([Buffer.alloc(20), Buffer.from([0x01])]);
+  t.throws(() => parseIntroduce2(bad), { message: /auth key type/ });
+});
+
+test('decryptIntroduce2 fails MAC check when subcredential is wrong', async (t) => {
+  const keys = generateHiddenServiceKeys();
+  const tp = deriveTimePeriodKeys({ keys, validAfter: new Date() });
+  const intro = generateIntroPointKeys(makePeerInfo(), Buffer.from(randomBytes(32)));
+  const rendezvousPoint = makePeerInfo();
+  const { payload } = await buildIntroduce1Payload({
+    introAuthKeyEd25519: intro.authKeyPublic,
+    serviceEncKey: intro.encKeyPublic,
+    N_hs_subcred: tp.subcredential,
+    rendezvousCookie: Buffer.from(randomBytes(20)),
+    rendezvousPoint,
+  });
+  const parsed = parseIntroduce2(payload);
+  await t.throwsAsync(
+    decryptIntroduce2({
+      parsed,
+      introPoint: intro,
+      subcredential: Buffer.from(randomBytes(32)), // wrong
+    }),
+    { message: /MAC verification failed/ }
+  );
+});
+
+// =============================================================================
+// hs-ntor: server completion vs. client completion → matching cipher pairs
+// =============================================================================
+
+test('completeHsNtorServer + hsNtorComplete agree on NTOR_KEY_SEED → cipher pairs', async (t) => {
+  const keys = generateHiddenServiceKeys();
+  const tp = deriveTimePeriodKeys({ keys, validAfter: new Date() });
+  const intro = generateIntroPointKeys(makePeerInfo(), Buffer.from(randomBytes(32)));
+
+  // Client builds INTRODUCE1 against this intro point (gives us X + state).
+  const rendezvousPoint = makePeerInfo();
+  const { payload, state } = await buildIntroduce1Payload({
+    introAuthKeyEd25519: intro.authKeyPublic,
+    serviceEncKey: intro.encKeyPublic,
+    N_hs_subcred: tp.subcredential,
+    rendezvousCookie: Buffer.from(randomBytes(20)),
+    rendezvousPoint,
+  });
+  const parsed = parseIntroduce2(payload);
+
+  // Server completes hs-ntor → produces RENDEZVOUS1 data + a cipher pair.
+  const { rendezvous1Data, cipherPair: serverPair } = completeHsNtorServer({
+    clientPk: parsed.clientPk,
+    introPoint: intro,
+    subcredential: tp.subcredential,
+  });
+
+  // Client receives RENDEZVOUS1 → derives NTOR_KEY_SEED → builds matching pair.
+  const Y = rendezvous1Data.subarray(0, 32);
+  const auth = rendezvous1Data.subarray(32, 64);
+  const { NTOR_KEY_SEED } = hsNtorComplete({ state, Y, auth });
+  const clientPair = makeHsRendezvousCipherPairFromKeySeed(NTOR_KEY_SEED);
+
+  // The roles flip on the server side. Encrypting with the client's "forward"
+  // produces ciphertext the server decrypts with its "backward". A simple
+  // symmetric round-trip through both ciphers should land back on plaintext.
+  const plaintext = Buffer.from(randomBytes(64));
+  const cipherText = await clientPair.forward.key.encrypt(plaintext);
+  const recovered = await serverPair.backward.key.decrypt(Buffer.from(cipherText));
+  t.deepEqual(Buffer.from(recovered), plaintext);
+
+  // And vice-versa: server forward → client backward should also round-trip.
+  const responsePlain = Buffer.from(randomBytes(48));
+  const responseCipher = await serverPair.forward.key.encrypt(responsePlain);
+  const responseRecovered = await clientPair.backward.key.decrypt(Buffer.from(responseCipher));
+  t.deepEqual(Buffer.from(responseRecovered), responsePlain);
+});
+
+test('hsNtorDeriveEncAndMac (client) and decryptIntroduce2 (server) agree on the encryption key', async (t) => {
+  // Direct sanity: server-side keys derived from EXP(b, X) match what the
+  // client side derives from EXP(x, B) since x25519 commutes.
+  const intro = generateIntroPointKeys(makePeerInfo(), Buffer.from(randomBytes(32)));
+  const subcred = Buffer.from(randomBytes(32));
+  const x = Buffer.from(x25519.utils.randomPrivateKey());
+  const X = Buffer.from(x25519.getPublicKey(x));
+
+  const { ENC_KEY: clientEnc, MAC_KEY: clientMac } = hsNtorDeriveEncAndMac({
+    x,
+    X,
+    B: intro.encKeyPublic,
+    AUTH_KEY: intro.authKeyPublic,
+    N_hs_subcred: subcred,
+  });
+
+  // Replicate server-side derivation (mirrors decryptIntroduce2 internals).
+  // We don't go through decryptIntroduce2 because that needs a real encrypted
+  // INTRODUCE2 payload; here we just compare KDF outputs.
+  void clientEnc;
+  void clientMac;
+
+  // We expect both sides to agree; the client mac/encryption keys should
+  // match what the server derives via the same KDF inputs (EXP(b,X) ==
+  // EXP(x,B) because x25519 is a Diffie-Hellman scheme).
+  t.pass();
+});
+
+// =============================================================================
+// publishHiddenService — surface + argument validation
+// =============================================================================
+
+import { publishHiddenService } from './hidden-service-host.ts';
+
+test('publishHiddenService is exported as a function', (t) => {
+  t.is(typeof publishHiddenService, 'function');
+});
+
+test('publishHiddenService rejects out-of-range ports', async (t) => {
+  // We don't need a real TorClient — the port check fires first.
+  await t.throwsAsync(
+    publishHiddenService({
+      // @ts-expect-error — passing a stub torClient on purpose
+      torClient: {},
+      port: 0,
+      onConnection: () => {},
+    }),
+    { message: /Invalid port/ }
+  );
+  await t.throwsAsync(
+    publishHiddenService({
+      // @ts-expect-error
+      torClient: {},
+      port: 70000,
+      onConnection: () => {},
+    }),
+    { message: /Invalid port/ }
+  );
+});
+
+test('publishHiddenService rejects non-function onConnection', async (t) => {
+  await t.throwsAsync(
+    publishHiddenService({
+      // @ts-expect-error
+      torClient: {},
+      port: 80,
+      // @ts-expect-error
+      onConnection: 'not a function',
+    }),
+    { message: /onConnection/ }
+  );
+});
+
+test('publishHiddenService identityKey is round-trippable as a 32-byte seed', (t) => {
+  // Independent of publishHiddenService (which needs a TorClient): just
+  // assert generateHiddenServiceKeys + loadHiddenServiceKeys preserve the
+  // seed exactly, which is what the round-trip property guarantees.
+  const a = generateHiddenServiceKeys();
+  const b = loadHiddenServiceKeys(a.identityPrivateKey);
+  t.deepEqual(Uint8Array.from(b.identityPrivateKey), Uint8Array.from(a.identityPrivateKey));
+  t.is(b.onionAddress, a.onionAddress);
+});

--- a/packages/tor/src/hidden-service-host.spec.ts
+++ b/packages/tor/src/hidden-service-host.spec.ts
@@ -141,10 +141,9 @@ test('signWithBlindedKey: rejects 32-byte blinded private key (must be expanded 
     periodNum: 1n,
     periodLengthMinutes: 1440n,
   });
-  t.throws(
-    () => signWithBlindedKey(Buffer.from('msg'), blindedPrivateKey, blindedPublicKey),
-    { message: /64 bytes/ }
-  );
+  t.throws(() => signWithBlindedKey(Buffer.from('msg'), blindedPrivateKey, blindedPublicKey), {
+    message: /64 bytes/,
+  });
 });
 
 test('deriveTimePeriodKeys: subcredential matches client deriveSubcredential', (t) => {
@@ -317,7 +316,10 @@ test('encryptDescriptorLayer: pads to multiple of 10000 bytes + emits MAC tail',
 test('generateDescriptor: produces a parseable v3 descriptor with required fields', async (t) => {
   const keys = generateHiddenServiceKeys();
   const tp = deriveTimePeriodKeys({ keys, validAfter: new Date() });
-  const intro: IntroductionPoint = generateIntroPointKeys(makePeerInfo(), Buffer.from(randomBytes(32)));
+  const intro: IntroductionPoint = generateIntroPointKeys(
+    makePeerInfo(),
+    Buffer.from(randomBytes(32))
+  );
 
   const descriptor = await generateDescriptor({
     keys,

--- a/packages/tor/src/hidden-service-host.spec.ts
+++ b/packages/tor/src/hidden-service-host.spec.ts
@@ -1,5 +1,15 @@
 import test from 'ava';
-import { x25519, ed25519, randomBytes, ed25519VerifySync } from 'tor-crypto';
+import {
+  x25519,
+  ed25519,
+  randomBytes,
+  ed25519VerifySync,
+  sha3,
+  mac,
+  dMac,
+  kdfShake256,
+  base32EncodeLowerNoPad,
+} from 'tor-crypto';
 import * as ed from '@noble/ed25519';
 
 import {
@@ -20,7 +30,6 @@ import {
   createEd25519Certificate,
   type IntroductionPoint,
 } from './hidden-service-host.ts';
-import { sha3, mac, dMac, kdfShake256, base32EncodeLowerNoPad } from 'tor-crypto';
 import {
   parseOnionV3Address,
   deriveBlindedPublicKey,
@@ -471,7 +480,7 @@ test('publishHiddenService rejects out-of-range ports', async (t) => {
   // We don't need a real TorClient — the port check fires first.
   await t.throwsAsync(
     publishHiddenService({
-      // @ts-expect-error — passing a stub torClient on purpose
+      // @ts-expect-error: stub TorClient — port validation runs before any torClient method is touched
       torClient: {},
       port: 0,
       onConnection: () => {},
@@ -480,7 +489,7 @@ test('publishHiddenService rejects out-of-range ports', async (t) => {
   );
   await t.throwsAsync(
     publishHiddenService({
-      // @ts-expect-error
+      // @ts-expect-error: stub TorClient — port validation runs before any torClient method is touched
       torClient: {},
       port: 70000,
       onConnection: () => {},
@@ -492,10 +501,10 @@ test('publishHiddenService rejects out-of-range ports', async (t) => {
 test('publishHiddenService rejects non-function onConnection', async (t) => {
   await t.throwsAsync(
     publishHiddenService({
-      // @ts-expect-error
+      // @ts-expect-error: stub TorClient — onConnection check runs before any torClient method is touched
       torClient: {},
       port: 80,
-      // @ts-expect-error
+      // @ts-expect-error: deliberately wrong type to exercise the runtime onConnection guard
       onConnection: 'not a function',
     }),
     { message: /onConnection/ }

--- a/packages/tor/src/hidden-service-host.spec.ts
+++ b/packages/tor/src/hidden-service-host.spec.ts
@@ -346,6 +346,45 @@ test('generateDescriptor: produces a parseable v3 descriptor with required field
   t.true(descriptor.includes('\nsignature '));
 });
 
+test('generateDescriptor: line-level base64 fields have NO `=` padding', async (t) => {
+  // c-tor's HSDir parser rejects descriptors with `=` padding on line-level
+  // base64 fields (introduction-point, onion-key ntor, enc-key ntor,
+  // desc-auth-ephemeral-key, signature) with a generic 400. Anything inside
+  // a -----BEGIN ... ----- PEM armor block is fine — those use padded base64.
+  const keys = generateHiddenServiceKeys();
+  const tp = deriveTimePeriodKeys({ keys, validAfter: new Date() });
+  const intro = generateIntroPointKeys(makePeerInfo(), Buffer.from(randomBytes(32)));
+  const descriptor = await generateDescriptor({
+    keys,
+    timePeriodKeys: tp,
+    introPoints: [intro],
+    revisionCounter: 1n,
+  });
+
+  // Strip every PEM block before checking — those legitimately have padding.
+  const stripped = descriptor.replace(
+    /-----BEGIN [A-Z0-9 ]+-----[\s\S]*?-----END [A-Z0-9 ]+-----/g,
+    ''
+  );
+
+  for (const field of [
+    'introduction-point',
+    'onion-key ntor',
+    'enc-key ntor',
+    'desc-auth-ephemeral-key',
+    'signature',
+    'auth-client',
+  ]) {
+    const lineRe = new RegExp(`^${field}\\s+(\\S.*?)\\s*$`, 'm');
+    const match = stripped.match(lineRe);
+    if (!match) continue;
+    t.false(
+      match[0].includes('='),
+      `field "${field}" must use base64-no-padding, got: ${match[0]}`
+    );
+  }
+});
+
 // =============================================================================
 // INTRODUCE2: client INTRODUCE1 -> server parse + decrypt round-trip
 // =============================================================================

--- a/packages/tor/src/hidden-service-host.spec.ts
+++ b/packages/tor/src/hidden-service-host.spec.ts
@@ -520,3 +520,41 @@ test('publishHiddenService identityKey is round-trippable as a 32-byte seed', (t
   t.deepEqual(Uint8Array.from(b.identityPrivateKey), Uint8Array.from(a.identityPrivateKey));
   t.is(b.onionAddress, a.onionAddress);
 });
+
+test('publishHiddenService rejects port arrays containing an invalid entry', async (t) => {
+  await t.throwsAsync(
+    publishHiddenService({
+      // @ts-expect-error: stub TorClient — port validation runs before any torClient method is touched
+      torClient: {},
+      port: [80, 0, 443],
+      onConnection: () => {},
+    }),
+    { message: /Invalid port 0/ }
+  );
+});
+
+test('publishHiddenService rejects an empty port array', async (t) => {
+  await t.throwsAsync(
+    publishHiddenService({
+      // @ts-expect-error: stub TorClient — port validation runs before any torClient method is touched
+      torClient: {},
+      port: [],
+      onConnection: () => {},
+    }),
+    { message: /at least one port required/ }
+  );
+});
+
+test('publishHiddenService rejects non-function acceptPort', async (t) => {
+  await t.throwsAsync(
+    publishHiddenService({
+      // @ts-expect-error: stub TorClient — acceptPort check runs before any torClient method is touched
+      torClient: {},
+      port: 80,
+      // @ts-expect-error: deliberately wrong type to exercise the runtime acceptPort guard
+      acceptPort: 'not a function',
+      onConnection: () => {},
+    }),
+    { message: /acceptPort must be a function/ }
+  );
+});

--- a/packages/tor/src/hidden-service-host.spec.ts
+++ b/packages/tor/src/hidden-service-host.spec.ts
@@ -15,17 +15,12 @@ import {
   decryptIntroduce2,
   completeHsNtorServer,
   generateDescriptor,
-  // private re-exports for primitive tests
-  sha3,
-  mac,
-  dMac,
-  kdfShake256,
-  base32EncodeLowerNoPad,
   curve25519PubkeyToEd25519,
   encryptDescriptorLayer,
   createEd25519Certificate,
   type IntroductionPoint,
 } from './hidden-service-host.ts';
+import { sha3, mac, dMac, kdfShake256, base32EncodeLowerNoPad } from 'tor-crypto';
 import {
   parseOnionV3Address,
   deriveBlindedPublicKey,

--- a/packages/tor/src/hidden-service-host.spec.ts
+++ b/packages/tor/src/hidden-service-host.spec.ts
@@ -25,7 +25,6 @@ import {
   parseOnionV3Address,
   deriveBlindedPublicKey,
   deriveSubcredential,
-  hsNtorDeriveEncAndMac,
   hsNtorComplete,
   buildIntroduce1Payload,
   makeHsRendezvousCipherPairFromKeySeed,
@@ -453,33 +452,10 @@ test('completeHsNtorServer + hsNtorComplete agree on NTOR_KEY_SEED → cipher pa
   t.deepEqual(Buffer.from(responseRecovered), responsePlain);
 });
 
-test('hsNtorDeriveEncAndMac (client) and decryptIntroduce2 (server) agree on the encryption key', async (t) => {
-  // Direct sanity: server-side keys derived from EXP(b, X) match what the
-  // client side derives from EXP(x, B) since x25519 commutes.
-  const intro = generateIntroPointKeys(makePeerInfo(), Buffer.from(randomBytes(32)));
-  const subcred = Buffer.from(randomBytes(32));
-  const x = Buffer.from(x25519.utils.randomPrivateKey());
-  const X = Buffer.from(x25519.getPublicKey(x));
-
-  const { ENC_KEY: clientEnc, MAC_KEY: clientMac } = hsNtorDeriveEncAndMac({
-    x,
-    X,
-    B: intro.encKeyPublic,
-    AUTH_KEY: intro.authKeyPublic,
-    N_hs_subcred: subcred,
-  });
-
-  // Replicate server-side derivation (mirrors decryptIntroduce2 internals).
-  // We don't go through decryptIntroduce2 because that needs a real encrypted
-  // INTRODUCE2 payload; here we just compare KDF outputs.
-  void clientEnc;
-  void clientMac;
-
-  // We expect both sides to agree; the client mac/encryption keys should
-  // match what the server derives via the same KDF inputs (EXP(b,X) ==
-  // EXP(x,B) because x25519 is a Diffie-Hellman scheme).
-  t.pass();
-});
+// (`hsNtorDeriveEncAndMac` ↔ server agreement is already covered by the
+// "decryptIntroduce2 round-trips against the client buildIntroduce1Payload"
+// test above — that exercises the full client-encrypt → server-decrypt
+// path including the KDF, so a separate placeholder is just dead weight.)
 
 // =============================================================================
 // publishHiddenService — surface + argument validation

--- a/packages/tor/src/hidden-service-host.ts
+++ b/packages/tor/src/hidden-service-host.ts
@@ -24,12 +24,21 @@ import { EventEmitter } from 'events';
 import {
   x25519,
   ed25519,
-  sha3_256,
-  shake256,
   randomBytes,
   ed25519VerifySync,
   makeAes256CtrKey,
   aes256CtrXor,
+  // rend-spec-v3 helpers (same impl shared with the client in hidden-service.ts):
+  sha3,
+  kdfShake256,
+  u64be,
+  mac,
+  dMac,
+  bytesToBigIntLE,
+  bigIntToBytesLE,
+  modInverse,
+  createSha3_256Hash,
+  base32EncodeLowerNoPad,
 } from 'tor-crypto';
 import * as ed from '@noble/ed25519';
 import { sha512 } from '@noble/hashes/sha512';
@@ -41,7 +50,6 @@ import {
   CircuitStream,
   type CircuitCipherPair,
   type PeerInfo,
-  type CopyableHash,
 } from './circuit.ts';
 import { type LinkSpecifier, LinkSpecifierTypes } from './messaging.ts';
 import { pickRelayWithFlags } from './build-circuit/util.ts';
@@ -80,98 +88,6 @@ const EXT_TYPE_SIGNED_WITH_ED25519_KEY = 0x04;
 
 // hs-ntor protocol id (rend-spec-v3 §3.3)
 const HS_NTOR_PROTOID = Buffer.from('tor-hs-ntor-curve25519-sha3-256-1', 'ascii');
-
-// ============================================================================
-// Small crypto helpers (mirror hidden-service.ts; intentionally duplicated to
-// avoid widening that file's public surface)
-// ============================================================================
-
-function sha3(...parts: Buffer[]): Buffer {
-  return Buffer.from(sha3_256(Buffer.concat(parts)));
-}
-
-function kdfShake256(input: Buffer, length: number): Buffer {
-  return Buffer.from(shake256(input, { dkLen: length }));
-}
-
-function u64be(n: bigint): Buffer {
-  const b = Buffer.alloc(8);
-  b.writeBigUInt64BE(n);
-  return b;
-}
-
-/** SHA3-256 MAC per rend-spec-v3 §0.3: SHA3_256(htonll(len(k)) | k | m). */
-function mac(key: Buffer, message: Buffer): Buffer {
-  return sha3(u64be(BigInt(key.length)), key, message);
-}
-
-/**
- * Domain-separated MAC for descriptor layers (rend-spec-v3 §2.5.1.1):
- * SHA3_256(htonll(len(macKey)) | macKey | htonll(len(salt)) | salt | encrypted).
- */
-function dMac(macKey: Buffer, salt: Buffer, encrypted: Buffer): Buffer {
-  return sha3(u64be(BigInt(macKey.length)), macKey, u64be(BigInt(salt.length)), salt, encrypted);
-}
-
-function bytesToBigIntLE(bytes: Uint8Array): bigint {
-  let n = 0n;
-  for (let i = bytes.length - 1; i >= 0; i--) {
-    n = (n << 8n) | BigInt(bytes[i] ?? 0);
-  }
-  return n;
-}
-
-function bigIntToBytesLE(n: bigint, length: number): Buffer {
-  const out = Buffer.alloc(length);
-  let temp = n;
-  for (let i = 0; i < length; i++) {
-    out[i] = Number(temp & 0xffn);
-    temp >>= 8n;
-  }
-  return out;
-}
-
-/** Modular inverse via Fermat's little theorem; p must be prime. */
-function modInverse(a: bigint, p: bigint): bigint {
-  // a^(p-2) mod p
-  let result = 1n;
-  let base = ((a % p) + p) % p;
-  let exp = p - 2n;
-  while (exp > 0n) {
-    if (exp & 1n) result = (result * base) % p;
-    base = (base * base) % p;
-    exp >>= 1n;
-  }
-  return result;
-}
-
-/** Browser-compatible CopyableHash backed by SHA3-256. */
-class Sha3_256Hash implements CopyableHash {
-  private accumulated: Uint8Array[] = [];
-  update(data: Buffer | Uint8Array): this {
-    this.accumulated.push(Uint8Array.from(data));
-    return this;
-  }
-  copy(): Sha3_256Hash {
-    const cloned = new Sha3_256Hash();
-    cloned.accumulated = [...this.accumulated];
-    return cloned;
-  }
-  digest(): Buffer {
-    const totalLength = this.accumulated.reduce((s, a) => s + a.length, 0);
-    const combined = new Uint8Array(totalLength);
-    let offset = 0;
-    for (const a of this.accumulated) {
-      combined.set(a, offset);
-      offset += a.length;
-    }
-    return Buffer.from(sha3_256(combined));
-  }
-}
-
-function createSha3_256Hash(): Sha3_256Hash {
-  return new Sha3_256Hash();
-}
 
 /**
  * Convert a curve25519 (Montgomery) public key to its ed25519 (Edwards)
@@ -271,24 +187,6 @@ export interface Introduce2Decrypted {
   onionKeyType: number;
   onionKey: Buffer;
   linkSpecifiers: LinkSpecifier[];
-}
-
-/** RFC4648 base32 alphabet, lowercase, unpadded. */
-function base32EncodeLowerNoPad(buf: Buffer): string {
-  const alphabet = 'abcdefghijklmnopqrstuvwxyz234567';
-  let bits = 0;
-  let value = 0;
-  let out = '';
-  for (let i = 0; i < buf.length; i++) {
-    value = (value << 8) | (buf[i] ?? 0);
-    bits += 8;
-    while (bits >= 5) {
-      out += alphabet[(value >>> (bits - 5)) & 31];
-      bits -= 5;
-    }
-  }
-  if (bits > 0) out += alphabet[(value << (5 - bits)) & 31];
-  return out;
 }
 
 // ============================================================================
@@ -1172,6 +1070,10 @@ export class HiddenServiceHost extends EventEmitter {
   private introPoints: IntroductionPoint[] = [];
   private revisionCounter: bigint = 0n;
   private running = false;
+  /** Set synchronously at the top of start(); cleared when start() resolves
+   *  or rejects. Prevents concurrent start() calls from racing past the
+   *  `if (this.running)` check. */
+  private starting = false;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private torClient: TorClient<any> | undefined;
   private refreshInterval: ReturnType<typeof setInterval> | undefined;
@@ -1209,7 +1111,13 @@ export class HiddenServiceHost extends EventEmitter {
     const perStepTimeoutMs = options.perStepTimeoutMs ?? 120_000;
     const descriptorRefreshMs = options.descriptorRefreshMs ?? 30 * 60 * 1000;
 
-    if (this.running) throw new Error('Hidden service is already running');
+    // `running` only flips true at the very end of start(); guard against
+    // concurrent start() calls racing past `if (this.running)` by also
+    // checking `starting` (set synchronously before the first await).
+    if (this.running || this.starting) {
+      throw new Error('Hidden service is already running');
+    }
+    this.starting = true;
 
     this.torClient = torClient;
     this.log(`starting hidden service ${this.keys.onionAddress}`);
@@ -1264,17 +1172,23 @@ export class HiddenServiceHost extends EventEmitter {
     this.log(`established ${this.introPoints.length} introduction points`);
 
     // 3. Upload the descriptor.
-    await this.uploadDescriptor();
+    try {
+      await this.uploadDescriptor();
 
-    this.running = true;
-    this.refreshInterval = setInterval(() => {
-      this.uploadDescriptor().catch((err) =>
-        this.log(`descriptor refresh failed: ${err instanceof Error ? err.message : err}`)
-      );
-    }, descriptorRefreshMs);
-    this.refreshInterval.unref?.();
+      this.running = true;
+      this.refreshInterval = setInterval(() => {
+        this.uploadDescriptor().catch((err) =>
+          this.log(`descriptor refresh failed: ${err instanceof Error ? err.message : err}`)
+        );
+      }, descriptorRefreshMs);
+      this.refreshInterval.unref?.();
 
-    this.log(`running at ${this.keys.onionAddress}`);
+      this.log(`running at ${this.keys.onionAddress}`);
+    } finally {
+      // Always clear the start-in-progress latch — both on success (running
+      // is now true) and on failure (caller may want to retry start()).
+      this.starting = false;
+    }
   }
 
   /** Number of intro points whose ESTABLISH_INTRO is currently acknowledged. */
@@ -1315,13 +1229,20 @@ export class HiddenServiceHost extends EventEmitter {
 
     // Wire up the INTRODUCE2 handler. We don't await — INTRODUCE2 cells are
     // unsolicited from our POV. Errors are logged but don't tear down the IP.
-    introCircuit.on('relay', (evt) => {
+    // The listener is detached on circuit 'destroyed' so a torn-down intro
+    // circuit doesn't keep `intro` + `this` alive in a closure indefinitely.
+    const onIntroduce2 = (evt: { streamId: number; relayCommand: number; data: Buffer }) => {
       if (evt.relayCommand === RelayCell.INTRODUCE2) {
         this.handleIntroduce2(intro, evt.data).catch((err) => {
           this.log(`INTRODUCE2 handling failed: ${err instanceof Error ? err.message : err}`);
           this.emit('introduce2-error', err);
         });
       }
+    };
+    introCircuit.on('relay', onIntroduce2);
+    introCircuit.once('destroyed', () => {
+      introCircuit.off('relay', onIntroduce2);
+      intro.established = false;
     });
   }
 
@@ -1358,9 +1279,14 @@ export class HiddenServiceHost extends EventEmitter {
 
     let uploads = 0;
     for (const hsdir of hsdirNodes.slice(0, 6)) {
+      // The circuit is allocated inside the try and torn down in the finally
+      // so an exception anywhere between buildCircuitToTarget() and the
+      // success path doesn't leak it (was the bug — circuit.destroy() was
+      // only on the success branch).
+      let circuit: Circuit | undefined;
       try {
         const peerInfo = await lookupPeerInfo(this.torClient.dirClient, hsdir);
-        const circuit = await this.torClient.buildCircuitToTarget(peerInfo);
+        circuit = await this.torClient.buildCircuitToTarget(peerInfo);
 
         const stream = await circuit.openDirectoryStream();
         const body = Buffer.from(descriptor, 'utf8');
@@ -1395,13 +1321,20 @@ export class HiddenServiceHost extends EventEmitter {
           uploads++;
           this.log(`uploaded to HSDir ${hsdir.nickname}`);
         } else {
-          this.log(`HSDir ${hsdir.nickname} rejected: ${responseText.split('\r\n')[0] ?? '(no response)'}`);
+          this.log(
+            `HSDir ${hsdir.nickname} rejected: ${responseText.split('\r\n')[0] ?? '(no response)'}`
+          );
         }
-        circuit.destroy();
       } catch (err) {
         this.log(
           `HSDir ${hsdir.nickname} upload failed: ${err instanceof Error ? err.message : err}`
         );
+      } finally {
+        try {
+          circuit?.destroy();
+        } catch {
+          // best-effort
+        }
       }
     }
     this.log(`descriptor uploaded to ${uploads}/${Math.min(6, hsdirNodes.length)} HSDirs`);
@@ -1438,22 +1371,38 @@ export class HiddenServiceHost extends EventEmitter {
 
     const rendCircuit = await this.torClient.buildCircuitToTarget(rendPeer);
 
-    const { rendezvous1Data, cipherPair } = completeHsNtorServer({
-      clientPk: parsed.clientPk,
-      introPoint: intro,
-      subcredential: this.timePeriodKeys.subcredential,
-    });
+    // Once the circuit is built, ANY failure between here and emitting
+    // 'rendezvous' must destroy it — otherwise we leak a 3-hop circuit per
+    // failed handshake. The success path skips the destroy and hands the
+    // circuit to the application.
+    let handedOff = false;
+    try {
+      const { rendezvous1Data, cipherPair } = completeHsNtorServer({
+        clientPk: parsed.clientPk,
+        introPoint: intro,
+        subcredential: this.timePeriodKeys.subcredential,
+      });
 
-    await rendCircuit.sendRelayMessage({
-      streamId: 0,
-      relayCommand: RelayCell.RENDEZVOUS1,
-      data: Buffer.concat([decrypted.rendezvousCookie, rendezvous1Data]),
-    });
-    rendCircuit.addVirtualHop(cipherPair);
+      await rendCircuit.sendRelayMessage({
+        streamId: 0,
+        relayCommand: RelayCell.RENDEZVOUS1,
+        data: Buffer.concat([decrypted.rendezvousCookie, rendezvous1Data]),
+      });
+      rendCircuit.addVirtualHop(cipherPair);
 
-    this.log('rendezvous complete; arming BEGIN handler');
-    this.attachServerSideStreamHandler(rendCircuit);
-    this.emit('rendezvous', { circuit: rendCircuit });
+      this.log('rendezvous complete; arming BEGIN handler');
+      this.attachServerSideStreamHandler(rendCircuit);
+      handedOff = true;
+      this.emit('rendezvous', { circuit: rendCircuit });
+    } finally {
+      if (!handedOff) {
+        try {
+          rendCircuit.destroy();
+        } catch {
+          // best-effort
+        }
+      }
+    }
   }
 
   /**
@@ -1486,56 +1435,56 @@ export class HiddenServiceHost extends EventEmitter {
       return stream;
     };
 
-    circuit.on(
-      'relay',
-      (evt: { streamId: number; relayCommand: number; data: Buffer }) => {
-        if (evt.relayCommand !== RelayCell.BEGIN) return;
-        // BEGIN body: <addr:port>\0<flags 4 bytes>
-        const nul = evt.data.indexOf(0);
-        if (nul < 0) {
-          this.log(`BEGIN streamId=${evt.streamId} missing NUL terminator`);
-          return;
-        }
-        const addrPort = evt.data.subarray(0, nul).toString('ascii');
-        const lastColon = addrPort.lastIndexOf(':');
-        const portStr = lastColon >= 0 ? addrPort.slice(lastColon + 1) : addrPort;
-        const port = Number.parseInt(portStr, 10);
+    const onBegin = (evt: { streamId: number; relayCommand: number; data: Buffer }) => {
+      if (evt.relayCommand !== RelayCell.BEGIN) return;
+      // BEGIN body: <addr:port>\0<flags 4 bytes>
+      const nul = evt.data.indexOf(0);
+      if (nul < 0) {
+        this.log(`BEGIN streamId=${evt.streamId} missing NUL terminator`);
+        return;
+      }
+      const addrPort = evt.data.subarray(0, nul).toString('ascii');
+      const lastColon = addrPort.lastIndexOf(':');
+      const portStr = lastColon >= 0 ? addrPort.slice(lastColon + 1) : addrPort;
+      const port = Number.parseInt(portStr, 10);
 
-        if (!this.acceptPort(port)) {
-          this.log(`refusing BEGIN streamId=${evt.streamId} for port=${port} (filtered)`);
-          // Reject with REASON_NOTDIRECTORY (6) — generic "we don't want this".
-          circuit.sendRelayMessage({
-            streamId: evt.streamId,
-            relayCommand: RelayCell.END,
-            data: Buffer.from([6]),
-          }).catch(() => undefined);
-          return;
-        }
-
-        const stream = acceptStreamId(evt.streamId, addrPort);
-        if (!stream) return;
-
-        // Send CONNECTED (8 zero bytes = no IPv4 + ttl=0) to accept.
+      if (!this.acceptPort(port)) {
+        this.log(`refusing BEGIN streamId=${evt.streamId} for port=${port} (filtered)`);
+        // Reject with REASON_NOTDIRECTORY (6) — generic "we don't want this".
         circuit
           .sendRelayMessage({
             streamId: evt.streamId,
-            relayCommand: RelayCell.CONNECTED,
-            data: Buffer.alloc(8),
+            relayCommand: RelayCell.END,
+            data: Buffer.from([6]),
           })
-          .then(() => {
-            // Hand the accepted stream to the application.
-            this.emit('connection', stream);
-            // Also forward to the per-host onConnection callback if set.
-            this.onConnectionCallback?.(stream);
-          })
-          .catch((err) => {
-            this.log(
-              `failed to send CONNECTED for stream ${evt.streamId}: ${err instanceof Error ? err.message : err}`
-            );
-            stream.destroy(err instanceof Error ? err : new Error(String(err)));
-          });
+          .catch(() => undefined);
+        return;
       }
-    );
+
+      const stream = acceptStreamId(evt.streamId, addrPort);
+      if (!stream) return;
+
+      // Send CONNECTED (8 zero bytes = no IPv4 + ttl=0) to accept.
+      circuit
+        .sendRelayMessage({
+          streamId: evt.streamId,
+          relayCommand: RelayCell.CONNECTED,
+          data: Buffer.alloc(8),
+        })
+        .then(() => {
+          this.emit('connection', stream);
+          this.onConnectionCallback?.(stream);
+        })
+        .catch((err) => {
+          this.log(
+            `failed to send CONNECTED for stream ${evt.streamId}: ${err instanceof Error ? err.message : err}`
+          );
+          stream.destroy(err instanceof Error ? err : new Error(String(err)));
+        });
+    };
+    circuit.on('relay', onBegin);
+    // Detach when the circuit goes away so the closure doesn't pin `this`.
+    circuit.once('destroyed', () => circuit.off('relay', onBegin));
   }
 
   /**
@@ -1582,25 +1531,16 @@ export class HiddenServiceHost extends EventEmitter {
     this.emit('stopped');
   }
 
-  /** Synchronous alias for {@link unpublish} (kept for backward-compat). */
-  stop(): void {
-    void this.unpublish();
-  }
 }
 
 // ============================================================================
-// Test helpers (re-exports)
+// Internal helpers exposed only for the spec test
 // ============================================================================
-//
-// These are private to the module but exposed for the spec tests so we can
-// assert on the small primitives (matching the surface PR #21 had).
+// (Generic crypto helpers — sha3, mac, dMac, kdfShake256,
+// base32EncodeLowerNoPad — live in `./hs-crypto.ts` and the spec imports
+// them from there directly.)
 
 export {
-  sha3,
-  mac,
-  dMac,
-  kdfShake256,
-  base32EncodeLowerNoPad,
   curve25519PubkeyToEd25519,
   encryptDescriptorLayer,
   createEd25519Certificate,

--- a/packages/tor/src/hidden-service-host.ts
+++ b/packages/tor/src/hidden-service-host.ts
@@ -174,6 +174,14 @@ export interface Introduce2Parsed {
   clientPk: Buffer;
   encryptedData: Buffer;
   macValue: Buffer;
+  /**
+   * The exact serialized bytes from LEGACY_KEY_ID through ENCRYPTED
+   * (everything in the cell minus the trailing 32-byte MAC). Per
+   * rend-spec-v3 §3.3.2 this is what the MAC covers — including any
+   * extension bytes, which we don't otherwise interpret. Store rather
+   * than reconstruct so an INTRODUCE2 with extensions still verifies.
+   */
+  payloadWithoutMac: Buffer;
 }
 
 /** Decrypted INTRODUCE2 contents. */
@@ -796,8 +804,12 @@ export function parseIntroduce2(payload: Buffer): Introduce2Parsed {
 
   const encryptedData = tail.subarray(0, tail.length - 32);
   const macValue = tail.subarray(tail.length - 32);
+  // Preserve the exact prefix the MAC covers (everything except the trailing
+  // 32-byte MAC). Reconstructing from parsed fields wouldn't round-trip when
+  // extensions are present.
+  const payloadWithoutMac = payload.subarray(0, payload.length - 32);
 
-  return { authKey, clientPk, encryptedData, macValue };
+  return { authKey, clientPk, encryptedData, macValue, payloadWithoutMac };
 }
 
 /**
@@ -835,18 +847,12 @@ export async function decryptIntroduce2(params: {
   const encKey = keys.subarray(0, S_KEY_LEN);
   const macKey = keys.subarray(S_KEY_LEN);
 
-  // MAC covers everything from LEGACY_KEY_ID through ENCRYPTED (rend-spec-v3
-  // §3.3.2). Reconstruct that input from parsed fields.
-  const macInput = Buffer.concat([
-    Buffer.alloc(20), // LEGACY_KEY_ID
-    Buffer.from([0x02]), // AUTH_KEY_TYPE
-    Buffer.from([0x00, 0x20]), // AUTH_KEY_LEN
-    parsed.authKey,
-    Buffer.from([0x00]), // N_EXT
-    parsed.clientPk,
-    parsed.encryptedData,
-  ]);
-  const expected = mac(macKey, macInput);
+  // MAC covers the exact serialized payload from LEGACY_KEY_ID through the
+  // end of ENCRYPTED, including any extensions (rend-spec-v3 §3.3.2). Use
+  // the original bytes preserved by parseIntroduce2() rather than
+  // reconstructing — a reconstruction with N_EXT=0 fails MAC verification
+  // for any INTRODUCE2 that actually carries extensions.
+  const expected = mac(macKey, parsed.payloadWithoutMac);
   if (!expected.equals(parsed.macValue)) {
     throw new Error('INTRODUCE2 MAC verification failed');
   }
@@ -1106,62 +1112,73 @@ export class HiddenServiceHost extends EventEmitter {
       throw new Error('Hidden service is already running');
     }
     this.starting = true;
-
     this.torClient = torClient;
     this.log(`starting hidden service ${this.keys.onionAddress}`);
 
-    const consensus = torClient.consensus;
-    if (!consensus.validAfter) {
-      throw new Error('TorClient consensus missing valid-after');
-    }
-
-    // 1. Derive descriptor key bundle for this consensus's time window.
-    const tpArgs: Parameters<typeof deriveTimePeriodKeys>[0] = {
-      keys: this.keys,
-      validAfter: consensus.validAfter,
-    };
-    if (consensus.freshUntil) tpArgs.freshUntil = consensus.freshUntil;
-    this.timePeriodKeys = deriveTimePeriodKeys(tpArgs);
-
-    // 2. Pick + establish intro points. Mainnet relays advertise rich flag
-    //    sets; chutney's tiny network usually only has Running+Stable, so we
-    //    accept any relay with Stable+Running and exclude obvious non-IPs.
-    const introCandidates = consensus.relays.filter((r) => {
-      const flags = r.flags ?? [];
-      if (flags.includes('BadExit')) return false;
-      if (flags.includes('Authority')) return false;
-      return flags.includes('Stable') && flags.includes('Running');
-    });
-    if (introCandidates.length === 0) {
-      throw new Error('No suitable introduction-point candidates in consensus');
-    }
-
-    const used: MicroDescNodeInfo[] = [];
-    for (let i = 0; i < numIntroPoints && used.length < introCandidates.length; i++) {
-      const relay = pickRelayWithFlags(introCandidates, [], used);
-      used.push(relay);
-      try {
-        const { peerInfo, ed25519IdentityKey } = await lookupPeerInfoWithEd25519IdentityKey(
-          torClient.dirClient,
-          relay
-        );
-        const intro = generateIntroPointKeys(peerInfo, ed25519IdentityKey);
-        await this.establishIntroPoint(intro, perStepTimeoutMs);
-        this.introPoints.push(intro);
-      } catch (err) {
-        this.log(
-          `intro point ${relay.nickname} failed: ${err instanceof Error ? err.message : err}`
-        );
-      }
-    }
-    if (this.introPoints.filter((i) => i.established).length === 0) {
-      throw new Error('Failed to establish any introduction points');
-    }
-    this.log(`established ${this.introPoints.length} introduction points`);
-
-    // 3. Upload the descriptor.
+    // Wrap the entire body so any failure clears the start-in-progress
+    // latch and rolls back side effects (intro circuits + torClient
+    // reference). Otherwise an early throw — e.g. missing valid-after,
+    // empty intro candidates, or all establishIntroPoint() calls failing —
+    // would leave `starting === true` forever and prevent retries.
+    let succeeded = false;
     try {
-      await this.uploadDescriptor();
+      const consensus = torClient.consensus;
+      if (!consensus.validAfter) {
+        throw new Error('TorClient consensus missing valid-after');
+      }
+
+      // 1. Derive descriptor key bundle for this consensus's time window.
+      const tpArgs: Parameters<typeof deriveTimePeriodKeys>[0] = {
+        keys: this.keys,
+        validAfter: consensus.validAfter,
+      };
+      if (consensus.freshUntil) tpArgs.freshUntil = consensus.freshUntil;
+      this.timePeriodKeys = deriveTimePeriodKeys(tpArgs);
+
+      // 2. Pick + establish intro points. Mainnet relays advertise rich flag
+      //    sets; chutney's tiny network usually only has Running+Stable, so
+      //    accept any relay with Stable+Running and exclude obvious non-IPs.
+      const introCandidates = consensus.relays.filter((r) => {
+        const flags = r.flags ?? [];
+        if (flags.includes('BadExit')) return false;
+        if (flags.includes('Authority')) return false;
+        return flags.includes('Stable') && flags.includes('Running');
+      });
+      if (introCandidates.length === 0) {
+        throw new Error('No suitable introduction-point candidates in consensus');
+      }
+
+      const used: MicroDescNodeInfo[] = [];
+      for (let i = 0; i < numIntroPoints && used.length < introCandidates.length; i++) {
+        const relay = pickRelayWithFlags(introCandidates, [], used);
+        used.push(relay);
+        try {
+          const { peerInfo, ed25519IdentityKey } = await lookupPeerInfoWithEd25519IdentityKey(
+            torClient.dirClient,
+            relay
+          );
+          const intro = generateIntroPointKeys(peerInfo, ed25519IdentityKey);
+          await this.establishIntroPoint(intro, perStepTimeoutMs);
+          this.introPoints.push(intro);
+        } catch (err) {
+          this.log(
+            `intro point ${relay.nickname} failed: ${err instanceof Error ? err.message : err}`
+          );
+        }
+      }
+      if (this.introPoints.filter((i) => i.established).length === 0) {
+        throw new Error('Failed to establish any introduction points');
+      }
+      this.log(`established ${this.introPoints.length} introduction points`);
+
+      // 3. Upload the descriptor. Initial publish must hit at least one
+      //    HSDir or the .onion isn't actually reachable — fail fast so the
+      //    caller can retry rather than silently advertising an unreachable
+      //    address. Periodic refreshes (below) tolerate transient failures.
+      const initialUploads = await this.uploadDescriptor();
+      if (initialUploads === 0) {
+        throw new Error('Failed to upload descriptor to any HSDir');
+      }
 
       this.running = true;
       this.refreshInterval = setInterval(() => {
@@ -1172,10 +1189,24 @@ export class HiddenServiceHost extends EventEmitter {
       this.refreshInterval.unref?.();
 
       this.log(`running at ${this.keys.onionAddress}`);
+      succeeded = true;
     } finally {
-      // Always clear the start-in-progress latch — both on success (running
-      // is now true) and on failure (caller may want to retry start()).
       this.starting = false;
+      if (!succeeded) {
+        // Roll back partial state so the caller can retry start() on a
+        // fresh torClient. Tear down whatever intro circuits did get
+        // established (their event listeners would otherwise hold `this`).
+        for (const intro of this.introPoints) {
+          try {
+            intro.circuit?.destroy();
+          } catch {
+            // best-effort
+          }
+        }
+        this.introPoints = [];
+        this.timePeriodKeys = undefined;
+        this.torClient = undefined;
+      }
     }
   }
 
@@ -1235,7 +1266,16 @@ export class HiddenServiceHost extends EventEmitter {
    * Build, sign, and POST the descriptor to the first ~6 HSDirs in the
    * consensus. Increments `revisionCounter` so refreshes look fresh.
    */
-  private async uploadDescriptor(): Promise<void> {
+  /**
+   * Build, sign, and POST the descriptor to the first ~6 HSDirs in the
+   * consensus. Increments `revisionCounter` so refreshes look fresh.
+   *
+   * Returns the number of HSDirs that returned a 2xx. The initial publish
+   * in {@link start} treats `0` as fatal so the host doesn't claim to be
+   * reachable when no HSDir actually accepted the descriptor; periodic
+   * refreshes ignore failures and rely on the next refresh to catch up.
+   */
+  private async uploadDescriptor(): Promise<number> {
     if (!this.timePeriodKeys || !this.torClient) {
       throw new Error('Hidden service not initialized');
     }
@@ -1243,7 +1283,7 @@ export class HiddenServiceHost extends EventEmitter {
     const established = this.introPoints.filter((i) => i.established);
     if (established.length === 0) {
       this.log('no established intro points; skipping descriptor upload');
-      return;
+      return 0;
     }
 
     this.revisionCounter++;
@@ -1259,7 +1299,7 @@ export class HiddenServiceHost extends EventEmitter {
     const hsdirNodes = consensus.relays.filter((r) => (r.flags ?? []).includes('HSDir'));
     if (hsdirNodes.length === 0) {
       this.log('no HSDir nodes in consensus; cannot publish');
-      return;
+      return 0;
     }
 
     let uploads = 0;
@@ -1323,6 +1363,7 @@ export class HiddenServiceHost extends EventEmitter {
       }
     }
     this.log(`descriptor uploaded to ${uploads}/${Math.min(6, hsdirNodes.length)} HSDirs`);
+    return uploads;
   }
 
   /**
@@ -1404,18 +1445,18 @@ export class HiddenServiceHost extends EventEmitter {
       const stream = new CircuitStream();
       stream.streamId = streamId;
       stream.destination = destination;
-      stream.write = async (data: Buffer) => {
-        await circuit.sendRelayMessage({
-          streamId,
-          relayCommand: RelayCell.DATA,
-          data,
-        });
-      };
-      // The connectionLatch is a client-side artifact; pre-resolve it so the
-      // existing CONNECTED handler in Circuit.receiveRelayMessage doesn't
-      // throw if a stray CONNECTED arrives, and so application code that
-      // does `await stream.write(...)` doesn't deadlock waiting on it.
+      // The connectionLatch is a client-side artifact (it settles on
+      // CONNECTED). Pre-resolve it so server-side write() doesn't deadlock
+      // waiting for a CONNECTED that we ourselves just sent.
       stream.connectionLatch.resolve();
+      // Delegate to Circuit.writeToStream so the application gets chunking
+      // (RELAY_PAYLOAD_LEN = 498 cap) plus circuit + stream package-window
+      // flow control for free. A direct sendRelayMessage with relayCommand
+      // = DATA would throw on writes >498 bytes and would also bypass
+      // SENDME backpressure on long replies.
+      stream.write = async (data: Buffer) => {
+        await circuit.writeToStream(stream, data);
+      };
       circuit.streams.push(stream);
       return stream;
     };

--- a/packages/tor/src/hidden-service-host.ts
+++ b/packages/tor/src/hidden-service-host.ts
@@ -25,7 +25,6 @@ import {
   x25519,
   ed25519,
   randomBytes,
-  ed25519VerifySync,
   makeAes256CtrKey,
   aes256CtrXor,
   // rend-spec-v3 helpers (same impl shared with the client in hidden-service.ts):
@@ -53,11 +52,7 @@ import {
   lookupPeerInfo,
   lookupPeerInfoWithEd25519IdentityKey,
 } from './directory-client.ts';
-import {
-  computeTimePeriod,
-  deriveBlindedPublicKey,
-  deriveSubcredential,
-} from './hidden-service.ts';
+import { computeTimePeriod, deriveSubcredential } from './hidden-service.ts';
 import type { VerifiedMicroDescConsensus, MicroDescNodeInfo } from './build-circuit/directory.ts';
 import type { TorClient } from './client.ts';
 
@@ -1068,7 +1063,6 @@ export class HiddenServiceHost extends EventEmitter {
    *  or rejects. Prevents concurrent start() calls from racing past the
    *  `if (this.running)` check. */
   private starting = false;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private torClient: TorClient<any> | undefined;
   private refreshInterval: ReturnType<typeof setInterval> | undefined;
   private log: (msg: string) => void;
@@ -1093,7 +1087,6 @@ export class HiddenServiceHost extends EventEmitter {
    * Snowflake-backed browser.
    */
   async start(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     torClient: TorClient<any>,
     options: {
       numIntroPoints?: number;
@@ -1580,7 +1573,6 @@ export interface PublishHiddenServiceOptions {
    * cast — the host only uses the channel-agnostic surface
    * (`consensus`, `dirClient`, `buildCircuitToTarget`).
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   torClient: TorClient<any>;
   /** Virtual port the onion service will accept BEGIN cells for. */
   port: number;

--- a/packages/tor/src/hidden-service-host.ts
+++ b/packages/tor/src/hidden-service-host.ts
@@ -1065,6 +1065,17 @@ export class HiddenServiceHost extends EventEmitter {
   private starting = false;
   private torClient: TorClient<any> | undefined;
   private refreshInterval: ReturnType<typeof setInterval> | undefined;
+  /** Target intro-point count, captured from start()'s options for use by
+   *  the churn watchdog (which has to know how many to keep alive). */
+  private targetIntroPoints = 3;
+  /** Per-step timeout for circuit / handshake operations during start() and
+   *  during churn replacement. */
+  private perStepTimeoutMs = 120_000;
+  /** RSA-id-hex strings that the watchdog should NOT reselect when picking
+   *  a replacement intro point — covers both currently-live and recently-dead
+   *  candidates so we don't immediately re-pick a flaky relay. Trimmed to the
+   *  most recent ~20 entries to bound memory across long churn loops. */
+  private recentIntroRelays: string[] = [];
   private log: (msg: string) => void;
 
   constructor(keys?: HiddenServiceKeys, options: { log?: (msg: string) => void } = {}) {
@@ -1106,6 +1117,8 @@ export class HiddenServiceHost extends EventEmitter {
     }
     this.starting = true;
     this.torClient = torClient;
+    this.targetIntroPoints = numIntroPoints;
+    this.perStepTimeoutMs = perStepTimeoutMs;
     this.log(`starting hidden service ${this.keys.onionAddress}`);
 
     // Wrap the entire body so any failure clears the start-in-progress
@@ -1145,6 +1158,7 @@ export class HiddenServiceHost extends EventEmitter {
       for (let i = 0; i < numIntroPoints && used.length < introCandidates.length; i++) {
         const relay = pickRelayWithFlags(introCandidates, [], used);
         used.push(relay);
+        this.rememberIntroRelay(relay.rsaIdDigest);
         try {
           const { peerInfo, ed25519IdentityKey } = await lookupPeerInfoWithEd25519IdentityKey(
             torClient.dirClient,
@@ -1252,7 +1266,88 @@ export class HiddenServiceHost extends EventEmitter {
     introCircuit.once('destroyed', () => {
       introCircuit.off('relay', onIntroduce2);
       intro.established = false;
+      // Churn watchdog: only kick off a replacement once the host is fully
+      // running. Don't trigger during start()'s rollback path (running===false,
+      // starting===true) or during unpublish() teardown (running===false).
+      if (this.running) {
+        this.replaceIntroPoint(intro).catch((err) => {
+          this.log(`intro replacement failed: ${err instanceof Error ? err.message : err}`);
+        });
+      }
     });
+  }
+
+  /** Track this RSA-id as recently-used so the watchdog won't immediately
+   *  re-pick the same relay (which is what would happen with a naive call to
+   *  pickRelayWithFlags on a small consensus). Bounded to ~20 entries. */
+  private rememberIntroRelay(rsaIdDigest: Buffer): void {
+    const hex = rsaIdDigest.toString('hex');
+    const idx = this.recentIntroRelays.indexOf(hex);
+    if (idx !== -1) this.recentIntroRelays.splice(idx, 1);
+    this.recentIntroRelays.push(hex);
+    if (this.recentIntroRelays.length > 20) this.recentIntroRelays.shift();
+  }
+
+  /**
+   * Pick a fresh relay, establish a new intro point on it, and republish
+   * the descriptor. Idempotent against concurrent calls (skips if we've
+   * already recovered to `targetIntroPoints`). Best-effort: on failure,
+   * logs and leaves the host with a degraded intro-point count.
+   */
+  private async replaceIntroPoint(failed: IntroductionPoint): Promise<void> {
+    if (!this.running || !this.torClient) return;
+
+    // Drop the failed entry from the list so numActiveIntroPoints() is
+    // accurate before we start picking a replacement.
+    const idx = this.introPoints.indexOf(failed);
+    if (idx !== -1) this.introPoints.splice(idx, 1);
+
+    if (this.numActiveIntroPoints() >= this.targetIntroPoints) {
+      this.log('intro-point churn: target already met, no replacement needed');
+      return;
+    }
+
+    const consensus = this.torClient.consensus;
+    const used = consensus.relays.filter((r) =>
+      this.recentIntroRelays.includes(r.rsaIdDigest.toString('hex'))
+    );
+    const candidates = consensus.relays.filter((r) => {
+      const flags = r.flags ?? [];
+      if (flags.includes('BadExit')) return false;
+      if (flags.includes('Authority')) return false;
+      return flags.includes('Stable') && flags.includes('Running');
+    });
+    if (candidates.length === 0) {
+      this.log('intro-point churn: no replacement candidates in consensus');
+      return;
+    }
+
+    let relay: MicroDescNodeInfo;
+    try {
+      relay = pickRelayWithFlags(candidates, [], used);
+    } catch {
+      // All candidates are in our recent set — fall back to allowing reuse.
+      relay = pickRelayWithFlags(candidates, [], []);
+    }
+    this.rememberIntroRelay(relay.rsaIdDigest);
+    this.log(`intro-point churn: rebuilding on ${relay.nickname}`);
+
+    try {
+      const { peerInfo, ed25519IdentityKey } = await lookupPeerInfoWithEd25519IdentityKey(
+        this.torClient.dirClient,
+        relay
+      );
+      const intro = generateIntroPointKeys(peerInfo, ed25519IdentityKey);
+      await this.establishIntroPoint(intro, this.perStepTimeoutMs);
+      this.introPoints.push(intro);
+      // Republish so the new IP shows up before clients rotate to a stale
+      // descriptor. Errors are logged inside uploadDescriptor.
+      await this.uploadDescriptor();
+    } catch (err) {
+      this.log(
+        `intro-point churn: replacement failed: ${err instanceof Error ? err.message : err}`
+      );
+    }
   }
 
   /**
@@ -1546,6 +1641,7 @@ export class HiddenServiceHost extends EventEmitter {
       }
     }
     this.introPoints = [];
+    this.recentIntroRelays = [];
     this.torClient = undefined;
     this.emit('stopped');
   }
@@ -1574,8 +1670,20 @@ export interface PublishHiddenServiceOptions {
    * (`consensus`, `dirClient`, `buildCircuitToTarget`).
    */
   torClient: TorClient<any>;
-  /** Virtual port the onion service will accept BEGIN cells for. */
-  port: number;
+  /**
+   * Virtual port(s) the onion service will accept BEGIN cells for. Pass a
+   * single number for a single-port service or an array for multi-port
+   * (real services routinely advertise more than one HiddenServicePort).
+   * Ignored when {@link acceptPort} is set.
+   */
+  port: number | number[];
+  /**
+   * Optional callback that overrides the default `port` membership check.
+   * Receives each BEGIN cell's destination port and must return true to
+   * accept. Use this when the set of acceptable ports is dynamic, or when
+   * you want a wildcard service.
+   */
+  acceptPort?: (port: number) => boolean;
   /** Called once per accepted incoming stream (one per BEGIN). */
   onConnection: (stream: CircuitStream) => void;
   /**
@@ -1614,10 +1722,32 @@ export interface HsHost {
  * `torClient` is not destroyed; the caller owns it.
  */
 export async function publishHiddenService(opts: PublishHiddenServiceOptions): Promise<HsHost> {
-  const { torClient, port, onConnection, identityKey, log } = opts;
-  if (port <= 0 || port > 0xffff) {
-    throw new Error(`Invalid port ${port}`);
+  const { torClient, port, acceptPort, onConnection, identityKey, log } = opts;
+
+  // Resolve the effective accept-port policy. When `acceptPort` is given it
+  // wins; otherwise we build a closure over the (single or array) `port`
+  // value. Validate every port in the static set so a typo fails fast rather
+  // than silently producing an unreachable service.
+  let acceptPortFn: (p: number) => boolean;
+  if (acceptPort) {
+    if (typeof acceptPort !== 'function') {
+      throw new Error('acceptPort must be a function');
+    }
+    acceptPortFn = acceptPort;
+  } else {
+    const portList = Array.isArray(port) ? port : [port];
+    if (portList.length === 0) {
+      throw new Error('port: at least one port required');
+    }
+    for (const p of portList) {
+      if (!Number.isInteger(p) || p <= 0 || p > 0xffff) {
+        throw new Error(`Invalid port ${p}`);
+      }
+    }
+    const portSet = new Set(portList);
+    acceptPortFn = (p) => portSet.has(p);
   }
+
   if (typeof onConnection !== 'function') {
     throw new Error('onConnection must be a function');
   }
@@ -1628,7 +1758,7 @@ export async function publishHiddenService(opts: PublishHiddenServiceOptions): P
 
   const constructorOpts = log ? { log } : {};
   const host = new HiddenServiceHost(keys, constructorOpts);
-  host.setAcceptPort((p) => p === port);
+  host.setAcceptPort(acceptPortFn);
   host.setOnConnection(onConnection);
 
   const startOpts: Parameters<HiddenServiceHost['start']>[1] = {};

--- a/packages/tor/src/hidden-service-host.ts
+++ b/packages/tor/src/hidden-service-host.ts
@@ -52,7 +52,7 @@ import {
   lookupPeerInfo,
   lookupPeerInfoWithEd25519IdentityKey,
 } from './directory-client.ts';
-import { computeTimePeriod, deriveSubcredential } from './hidden-service.ts';
+import { computeTimePeriod, deriveSubcredential, toBase64NoPad } from './hidden-service.ts';
 import type { VerifiedMicroDescConsensus, MicroDescNodeInfo } from './build-circuit/directory.ts';
 import type { TorClient } from './client.ts';
 
@@ -546,8 +546,12 @@ function generateInnerLayerPlaintext(params: {
 
   for (const intro of params.introPoints) {
     const lsBlock = buildLinkSpecifiersBlock(intro.peerInfo.linkSpecifiers);
-    lines.push(`introduction-point ${lsBlock.toString('base64')}`);
-    lines.push(`onion-key ntor ${intro.peerInfo.onionKey.toString('base64')}`);
+    // rend-spec-v3 §2.5.2: all the per-line base64 fields here are emitted
+    // WITHOUT `=` padding. C-tor's HSDir parser rejects the entire descriptor
+    // with "400 Invalid HS descriptor" if padding shows up — was the cause
+    // of the all-HSDirs-rejecting failure on the first chutney run.
+    lines.push(`introduction-point ${toBase64NoPad(lsBlock)}`);
+    lines.push(`onion-key ntor ${toBase64NoPad(intro.peerInfo.onionKey)}`);
 
     // auth-key cert (type 0x09): certifies the IP's auth ed25519 key,
     // signed by the descriptor signing key.
@@ -563,7 +567,7 @@ function generateInnerLayerPlaintext(params: {
     lines.push('auth-key');
     lines.push(...pemBlock('ED25519 CERT', authKeyCert));
 
-    lines.push(`enc-key ntor ${intro.encKeyPublic.toString('base64')}`);
+    lines.push(`enc-key ntor ${toBase64NoPad(intro.encKeyPublic)}`);
 
     // enc-key-cert (type 0x0b): certifies the ed25519-equivalent of the IP's
     // curve25519 enc key (proposal 228 appendix A), signed by the descriptor
@@ -603,13 +607,13 @@ function generateFirstLayerPlaintext(innerEncrypted: Buffer): Buffer {
 
   const lines: string[] = [];
   lines.push('desc-auth-type x25519');
-  lines.push(`desc-auth-ephemeral-key ${ephPub.toString('base64')}`);
+  lines.push(`desc-auth-ephemeral-key ${toBase64NoPad(ephPub)}`);
 
   // Padding to AUTH_CLIENT_PADDING_MULTIPLE entries with random fakes.
   for (let i = 0; i < AUTH_CLIENT_PADDING_MULTIPLE; i++) {
-    const clientId = Buffer.from(randomBytes(8)).toString('base64').replace(/=+$/, '');
-    const iv = Buffer.from(randomBytes(16)).toString('base64').replace(/=+$/, '');
-    const cookie = Buffer.from(randomBytes(16)).toString('base64').replace(/=+$/, '');
+    const clientId = toBase64NoPad(Buffer.from(randomBytes(8)));
+    const iv = toBase64NoPad(Buffer.from(randomBytes(16)));
+    const cookie = toBase64NoPad(Buffer.from(randomBytes(16)));
     lines.push(`auth-client ${clientId} ${iv} ${cookie}`);
   }
 
@@ -697,7 +701,7 @@ export async function generateDescriptor(params: {
     Buffer.from(descriptorBody, 'utf8'),
   ]);
   const signature = Buffer.from(ed.sign(sigInput, timePeriodKeys.descriptorSigningPrivateKey));
-  lines.push('signature ' + signature.toString('base64'));
+  lines.push('signature ' + toBase64NoPad(signature));
 
   return lines.join('\n') + '\n';
 }

--- a/packages/tor/src/hidden-service-host.ts
+++ b/packages/tor/src/hidden-service-host.ts
@@ -1,0 +1,1696 @@
+/**
+ * Hidden-service hosting (rend-spec-v3 server side).
+ *
+ * Pairs with the client implementation in `./hidden-service.ts`. This module
+ * generates v3 onion identities, builds + uploads descriptors, accepts
+ * INTRODUCE2 cells at established introduction points, and completes the
+ * hs-ntor handshake at rendezvous points.
+ *
+ * Protocol references (sections cited in the relevant function):
+ *   - rend-spec-v3.txt §2.5  (descriptor format)
+ *   - rend-spec-v3.txt §3.1  (ESTABLISH_INTRO)
+ *   - rend-spec-v3.txt §3.3  (INTRODUCE2)
+ *   - rend-spec-v3.txt §4    (rendezvous + hs-ntor)
+ *   - tor-spec.txt §5.2.2    (ntor KH used as ESTABLISH_INTRO MAC_KEY)
+ *   - proposal 228 appendix A (curve25519 -> ed25519 enc-key conversion)
+ */
+
+// `events` is the standard Node module name and is also the package name
+// browser bundlers (webpack, vite via vite-plugin-node-polyfills, etc.)
+// shim to a portable EventEmitter implementation. This keeps the host
+// usable in service-worker contexts where the goblin-chat-tor example
+// runs.
+import { EventEmitter } from 'events';
+import {
+  x25519,
+  ed25519,
+  sha3_256,
+  shake256,
+  randomBytes,
+  ed25519VerifySync,
+  makeAes256CtrKey,
+  aes256CtrXor,
+} from 'tor-crypto';
+import * as ed from '@noble/ed25519';
+import { sha512 } from '@noble/hashes/sha512';
+
+import { BytesReader, bufferFromUint } from './util.ts';
+import { RelayCell } from './relay-cell.ts';
+import {
+  Circuit,
+  CircuitStream,
+  type CircuitCipherPair,
+  type PeerInfo,
+  type CopyableHash,
+} from './circuit.ts';
+import { type LinkSpecifier, LinkSpecifierTypes } from './messaging.ts';
+import { pickRelayWithFlags } from './build-circuit/util.ts';
+import {
+  DirectoryClient,
+  lookupPeerInfo,
+  lookupPeerInfoWithEd25519IdentityKey,
+} from './directory-client.ts';
+import {
+  computeTimePeriod,
+  deriveBlindedPublicKey,
+  deriveSubcredential,
+} from './hidden-service.ts';
+import type { VerifiedMicroDescConsensus, MicroDescNodeInfo } from './build-circuit/directory.ts';
+import type { TorClient } from './client.ts';
+
+// `@noble/ed25519` needs sha512Sync configured for sync verify/sign. The
+// `tor-crypto/curves` module imported above runs that wiring at load time,
+// so calling `ed.sign(...)` works directly. We still keep the `sha512`
+// import — it's used for the blinded-key seed-expansion and the RH' nonce
+// derivation (both SHA-512 per Tor's donna implementation).
+
+// rend-spec-v3 constants
+const HASH_LEN = 32; // SHA3-256
+const MAC_KEY_LEN = 32;
+const S_KEY_LEN = 32; // AES-256 key
+const S_IV_LEN = 16; // AES block / iv length
+const DESCRIPTOR_PADDING_MULTIPLE = 10000;
+const AUTH_CLIENT_PADDING_MULTIPLE = 16;
+
+// Ed25519 certificate types (cert-spec.txt + rend-spec-v3 §2.5.1)
+const CERT_TYPE_HS_BLINDED_ID_V_SIGNING = 0x08;
+const CERT_TYPE_HS_IP_V_SIGNING = 0x09;
+const CERT_TYPE_HS_IP_CC_SIGNING = 0x0b;
+const EXT_TYPE_SIGNED_WITH_ED25519_KEY = 0x04;
+
+// hs-ntor protocol id (rend-spec-v3 §3.3)
+const HS_NTOR_PROTOID = Buffer.from('tor-hs-ntor-curve25519-sha3-256-1', 'ascii');
+
+// ============================================================================
+// Small crypto helpers (mirror hidden-service.ts; intentionally duplicated to
+// avoid widening that file's public surface)
+// ============================================================================
+
+function sha3(...parts: Buffer[]): Buffer {
+  return Buffer.from(sha3_256(Buffer.concat(parts)));
+}
+
+function kdfShake256(input: Buffer, length: number): Buffer {
+  return Buffer.from(shake256(input, { dkLen: length }));
+}
+
+function u64be(n: bigint): Buffer {
+  const b = Buffer.alloc(8);
+  b.writeBigUInt64BE(n);
+  return b;
+}
+
+/** SHA3-256 MAC per rend-spec-v3 §0.3: SHA3_256(htonll(len(k)) | k | m). */
+function mac(key: Buffer, message: Buffer): Buffer {
+  return sha3(u64be(BigInt(key.length)), key, message);
+}
+
+/**
+ * Domain-separated MAC for descriptor layers (rend-spec-v3 §2.5.1.1):
+ * SHA3_256(htonll(len(macKey)) | macKey | htonll(len(salt)) | salt | encrypted).
+ */
+function dMac(macKey: Buffer, salt: Buffer, encrypted: Buffer): Buffer {
+  return sha3(u64be(BigInt(macKey.length)), macKey, u64be(BigInt(salt.length)), salt, encrypted);
+}
+
+function bytesToBigIntLE(bytes: Uint8Array): bigint {
+  let n = 0n;
+  for (let i = bytes.length - 1; i >= 0; i--) {
+    n = (n << 8n) | BigInt(bytes[i] ?? 0);
+  }
+  return n;
+}
+
+function bigIntToBytesLE(n: bigint, length: number): Buffer {
+  const out = Buffer.alloc(length);
+  let temp = n;
+  for (let i = 0; i < length; i++) {
+    out[i] = Number(temp & 0xffn);
+    temp >>= 8n;
+  }
+  return out;
+}
+
+/** Modular inverse via Fermat's little theorem; p must be prime. */
+function modInverse(a: bigint, p: bigint): bigint {
+  // a^(p-2) mod p
+  let result = 1n;
+  let base = ((a % p) + p) % p;
+  let exp = p - 2n;
+  while (exp > 0n) {
+    if (exp & 1n) result = (result * base) % p;
+    base = (base * base) % p;
+    exp >>= 1n;
+  }
+  return result;
+}
+
+/** Browser-compatible CopyableHash backed by SHA3-256. */
+class Sha3_256Hash implements CopyableHash {
+  private accumulated: Uint8Array[] = [];
+  update(data: Buffer | Uint8Array): this {
+    this.accumulated.push(Uint8Array.from(data));
+    return this;
+  }
+  copy(): Sha3_256Hash {
+    const cloned = new Sha3_256Hash();
+    cloned.accumulated = [...this.accumulated];
+    return cloned;
+  }
+  digest(): Buffer {
+    const totalLength = this.accumulated.reduce((s, a) => s + a.length, 0);
+    const combined = new Uint8Array(totalLength);
+    let offset = 0;
+    for (const a of this.accumulated) {
+      combined.set(a, offset);
+      offset += a.length;
+    }
+    return Buffer.from(sha3_256(combined));
+  }
+}
+
+function createSha3_256Hash(): Sha3_256Hash {
+  return new Sha3_256Hash();
+}
+
+/**
+ * Convert a curve25519 (Montgomery) public key to its ed25519 (Edwards)
+ * equivalent per proposal 228 appendix A.
+ *
+ * The Edwards y-coordinate is `(u - 1) / (u + 1) mod p`, where u is the
+ * Montgomery x-coordinate (the curve25519 pubkey, little-endian). The sign
+ * bit (high bit of the last byte) is set to 0 — proposal 228 requires both
+ * sides of the certificate use the same convention, and 0 is canonical.
+ *
+ * Used to build the certified key inside the descriptor's `enc-key-cert`
+ * (rend-spec-v3 §2.5.2.2).
+ */
+function curve25519PubkeyToEd25519(curvePub: Buffer): Buffer {
+  if (curvePub.length !== 32) {
+    throw new Error(`curve25519 public key must be 32 bytes, got ${curvePub.length}`);
+  }
+  const p = ed25519.CURVE.Fp.ORDER; // 2^255 - 19
+  // Curve25519 spec: clamp the high bit of the input u to zero before use.
+  // Tor's encoding doesn't bother because well-formed pubkeys already have
+  // the high bit clear, but we mask defensively.
+  const ucopy = Buffer.from(curvePub);
+  ucopy[31] = (ucopy[31] ?? 0) & 0x7f;
+  const u = bytesToBigIntLE(ucopy);
+  const num = (u + p - 1n) % p;
+  const den = (u + 1n) % p;
+  const denInv = modInverse(den, p);
+  const y = (num * denInv) % p;
+  const out = bigIntToBytesLE(y, 32);
+  // Clear sign bit (use canonical positive x). Proposal 228 §A: sign = 0.
+  out[31] = (out[31] ?? 0) & 0x7f;
+  return out;
+}
+
+// ============================================================================
+// Public types
+// ============================================================================
+
+/** Hidden-service identity (long-term). */
+export interface HiddenServiceKeys {
+  /** Long-term identity private key (32-byte ed25519 seed). */
+  identityPrivateKey: Buffer;
+  /** Long-term identity public key (32 bytes). */
+  identityPublicKey: Buffer;
+  /** Computed .onion address without the trailing `.onion`. */
+  onionAddressBase: string;
+  /** Full onion address, e.g. `xxxx.onion`. */
+  onionAddress: string;
+}
+
+/** Time-period-specific descriptor key material. */
+export interface TimePeriodKeys {
+  periodNum: bigint;
+  periodLengthMinutes: bigint;
+  /** Canonical encoding of the blinded scalar `a'` (32 bytes). Not a seed. */
+  blindedPrivateKey: Buffer;
+  /** Blinded public key `BASE * a'` (32 bytes). */
+  blindedPublicKey: Buffer;
+  /** 64-byte donna-format expanded secret for blinded EdDSA signing. */
+  blindedSigningKey: Buffer;
+  subcredential: Buffer;
+  /** Fresh 32-byte ed25519 seed for the descriptor signing key. */
+  descriptorSigningPrivateKey: Buffer;
+  descriptorSigningPublicKey: Buffer;
+}
+
+/** A live (or pending) introduction point with its per-IP key material. */
+export interface IntroductionPoint {
+  peerInfo: PeerInfo;
+  /** Ed25519 identity key of the IP relay (used for the Ed25519Id link spec). */
+  ed25519IdentityKey: Buffer;
+  /** KP_hs_ipt_sid private (ed25519 seed). */
+  authKeyPrivate: Buffer;
+  /** KP_hs_ipt_sid public. */
+  authKeyPublic: Buffer;
+  /** KP_hss_ntor private (curve25519 scalar). */
+  encKeyPrivate: Buffer;
+  /** KP_hss_ntor public (curve25519 pubkey). */
+  encKeyPublic: Buffer;
+  /** Live circuit to the IP (set after ESTABLISH_INTRO succeeds). */
+  circuit: Circuit | undefined;
+  /** True after we observe INTRO_ESTABLISHED. */
+  established: boolean;
+}
+
+/** Parsed INTRODUCE2 payload (rend-spec-v3 §3.3). */
+export interface Introduce2Parsed {
+  authKey: Buffer;
+  clientPk: Buffer;
+  encryptedData: Buffer;
+  macValue: Buffer;
+}
+
+/** Decrypted INTRODUCE2 contents. */
+export interface Introduce2Decrypted {
+  rendezvousCookie: Buffer;
+  onionKeyType: number;
+  onionKey: Buffer;
+  linkSpecifiers: LinkSpecifier[];
+}
+
+/** RFC4648 base32 alphabet, lowercase, unpadded. */
+function base32EncodeLowerNoPad(buf: Buffer): string {
+  const alphabet = 'abcdefghijklmnopqrstuvwxyz234567';
+  let bits = 0;
+  let value = 0;
+  let out = '';
+  for (let i = 0; i < buf.length; i++) {
+    value = (value << 8) | (buf[i] ?? 0);
+    bits += 8;
+    while (bits >= 5) {
+      out += alphabet[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) out += alphabet[(value << (5 - bits)) & 31];
+  return out;
+}
+
+// ============================================================================
+// Onion address + key generation
+// ============================================================================
+
+/**
+ * Compute the v3 onion address from an ed25519 identity public key.
+ * Format (address-spec.txt §6): base32(pubkey || checksum || version) + ".onion"
+ * where checksum = SHA3-256(".onion checksum" || pubkey || version)[:2].
+ */
+export function computeOnionAddress(identityPublicKey: Buffer): string {
+  const version = Buffer.from([0x03]);
+  const checksum = sha3(
+    Buffer.from('.onion checksum', 'ascii'),
+    identityPublicKey,
+    version
+  ).subarray(0, 2);
+  return base32EncodeLowerNoPad(Buffer.concat([identityPublicKey, checksum, version])) + '.onion';
+}
+
+function makeKeysFromSeed(identityPrivateKey: Buffer): HiddenServiceKeys {
+  const identityPublicKey = Buffer.from(ed25519.getPublicKey(identityPrivateKey));
+  const onionAddress = computeOnionAddress(identityPublicKey);
+  const onionAddressBase = onionAddress.slice(0, -'.onion'.length);
+  return { identityPrivateKey, identityPublicKey, onionAddressBase, onionAddress };
+}
+
+/** Generate a fresh hidden-service identity keypair + onion address. */
+export function generateHiddenServiceKeys(): HiddenServiceKeys {
+  return makeKeysFromSeed(Buffer.from(ed25519.utils.randomPrivateKey()));
+}
+
+/** Recover a hidden-service identity from an existing 32-byte ed25519 seed. */
+export function loadHiddenServiceKeys(identityPrivateKey: Buffer): HiddenServiceKeys {
+  if (identityPrivateKey.length !== 32) {
+    throw new Error(`identityPrivateKey must be 32 bytes, got ${identityPrivateKey.length}`);
+  }
+  return makeKeysFromSeed(identityPrivateKey);
+}
+
+// ============================================================================
+// Blinded key derivation (private side)
+// ============================================================================
+
+/**
+ * Derive the blinded ed25519 keypair for a given time period.
+ *
+ * The blinding factor `h` is the same as on the client side
+ * (`deriveBlindedPublicKey` in hidden-service.ts). Multiplying the identity
+ * scalar by `h mod n` yields the blinded scalar; the corresponding public
+ * key is `BASE * blindedScalar`. See rend-spec-v3 §A.2.
+ *
+ * Returns:
+ *   - `blindedPrivateKey` (32 bytes): canonical little-endian encoding of
+ *     the blinded scalar `a'`. NOT a seed — must be signed with
+ *     {@link signWithBlindedKey}, which expects the donna-format expanded
+ *     secret `a' || RH'` returned via `blindedSigningKey`.
+ *   - `blindedPublicKey` (32 bytes): `BASE * a'`.
+ *   - `blindedSigningKey` (64 bytes): the donna-format expanded secret
+ *     `a' || RH'` ready to feed to {@link signWithBlindedKey}. Per Tor's
+ *     `ed25519_donna_blind_secret_key`, RH' = SHA-512("Derive temporary
+ *     signing key hash input" || RH)[:32], where RH = SHA-512(seed)[32:64].
+ */
+export function deriveBlindedPrivateKey(params: {
+  identityPrivateKey: Buffer;
+  periodNum: bigint;
+  periodLengthMinutes: bigint;
+}): { blindedPrivateKey: Buffer; blindedPublicKey: Buffer; blindedSigningKey: Buffer } {
+  const blindStr = Buffer.from('Derive temporary signing key\0', 'ascii');
+  const basepointStr = Buffer.from(
+    '(15112221349535400772501151409588531511454012693041857206046113283949847762202, ' +
+      '46316835694926478169428394003475163141307993866256225615783033603165251855960)',
+    'ascii'
+  );
+  const identityPublicKey = Buffer.from(ed25519.getPublicKey(params.identityPrivateKey));
+  const N = Buffer.concat([
+    Buffer.from('key-blind', 'ascii'),
+    u64be(params.periodNum),
+    u64be(params.periodLengthMinutes),
+  ]);
+  const h = Buffer.from(sha3(blindStr, identityPublicKey, basepointStr, N));
+  // Clamp `h` per ed25519
+  h[0] = (h[0] ?? 0) & 248;
+  h[31] = (h[31] ?? 0) & 63;
+  h[31] = (h[31] ?? 0) | 64;
+  const hScalar = bytesToBigIntLE(h) % ed25519.CURVE.n;
+
+  // Identity scalar = lower 32 bytes of SHA-512(seed), clamped.
+  const expanded = Buffer.from(sha512(params.identityPrivateKey));
+  const identityScalarBytes = Buffer.from(expanded.subarray(0, 32));
+  identityScalarBytes[0] = (identityScalarBytes[0] ?? 0) & 248;
+  identityScalarBytes[31] = (identityScalarBytes[31] ?? 0) & 63;
+  identityScalarBytes[31] = (identityScalarBytes[31] ?? 0) | 64;
+  const identityScalar = bytesToBigIntLE(identityScalarBytes);
+
+  const blindedScalar = (identityScalar * hScalar) % ed25519.CURVE.n;
+  const blindedPrivateKey = bigIntToBytesLE(blindedScalar, 32);
+  const blindedPublicKey = Buffer.from(
+    ed25519.ExtendedPoint.BASE.multiply(blindedScalar).toRawBytes()
+  );
+
+  // Build the 64-byte donna-format expanded secret needed for blinded EdDSA
+  // signatures. RH' = SHA-512("Derive temporary signing key hash input" || RH).
+  const RH = expanded.subarray(32, 64);
+  const RHPrime = Buffer.from(
+    sha512(
+      Buffer.concat([Buffer.from('Derive temporary signing key hash input', 'ascii'), RH])
+    )
+  ).subarray(0, 32);
+  const blindedSigningKey = Buffer.concat([blindedPrivateKey, RHPrime]);
+
+  return { blindedPrivateKey, blindedPublicKey, blindedSigningKey };
+}
+
+/**
+ * Sign `msg` with a blinded ed25519 expanded secret key per RFC 8032 EdDSA,
+ * with the donna twist Tor uses: the scalar is taken directly (not
+ * re-expanded/clamped), and the nonce prefix is the second 32 bytes of the
+ * input. This matches `ed25519_donna_open_/sign_` behavior used by Tor for
+ * blinded keys (see rend-spec-v3 §A.2 and Tor's
+ * `ed25519_donna_blind_secret_key` / `ed25519_donna_sign`).
+ *
+ * Used to sign the descriptor-signing-key cert and any other artefact whose
+ * authority chains back to the blinded key. Regular descriptor body / cert
+ * signing uses the freshly-generated descriptor signing keypair via
+ * `@noble/ed25519`'s normal `ed.sign`.
+ */
+export function signWithBlindedKey(
+  msg: Buffer,
+  blindedSigningKey: Buffer,
+  blindedPublicKey: Buffer
+): Buffer {
+  if (blindedSigningKey.length !== 64) {
+    throw new Error(`blindedSigningKey must be 64 bytes, got ${blindedSigningKey.length}`);
+  }
+  const a = bytesToBigIntLE(blindedSigningKey.subarray(0, 32));
+  const RHPrime = blindedSigningKey.subarray(32, 64);
+  const L = ed25519.CURVE.n;
+
+  // r = SHA-512(RH' || msg) mod L
+  const rHash = Buffer.from(sha512(Buffer.concat([RHPrime, msg])));
+  const r = bytesToBigIntLE(rHash) % L;
+
+  // R = r * BASE
+  const Rpoint = ed25519.ExtendedPoint.BASE.multiply(r);
+  const R = Buffer.from(Rpoint.toRawBytes());
+
+  // k = SHA-512(R || A || msg) mod L
+  const kHash = Buffer.from(sha512(Buffer.concat([R, blindedPublicKey, msg])));
+  const k = bytesToBigIntLE(kHash) % L;
+
+  // S = (r + k * a) mod L
+  const S = (r + ((k * a) % L)) % L;
+  const Sbytes = bigIntToBytesLE(S, 32);
+
+  return Buffer.concat([R, Sbytes]);
+}
+
+/**
+ * Derive the full descriptor key bundle for a given consensus's time window.
+ * Generates a fresh descriptor signing keypair on each call.
+ */
+export function deriveTimePeriodKeys(params: {
+  keys: HiddenServiceKeys;
+  validAfter: Date;
+  freshUntil?: Date;
+  hsdirIntervalMinutes?: number;
+}): TimePeriodKeys {
+  const tpArgs: Parameters<typeof computeTimePeriod>[0] = { validAfter: params.validAfter };
+  if (params.freshUntil !== undefined) tpArgs.freshUntil = params.freshUntil;
+  if (params.hsdirIntervalMinutes !== undefined) {
+    tpArgs.hsdirIntervalMinutes = params.hsdirIntervalMinutes;
+  }
+  const { periodNum, periodLengthMinutes } = computeTimePeriod(tpArgs);
+
+  const { blindedPrivateKey, blindedPublicKey, blindedSigningKey } = deriveBlindedPrivateKey({
+    identityPrivateKey: params.keys.identityPrivateKey,
+    periodNum,
+    periodLengthMinutes,
+  });
+
+  const subcredential = deriveSubcredential({
+    publicIdentityKey: params.keys.identityPublicKey,
+    blindedPublicKey,
+  });
+
+  const descriptorSigningPrivateKey = Buffer.from(ed25519.utils.randomPrivateKey());
+  const descriptorSigningPublicKey = Buffer.from(
+    ed25519.getPublicKey(descriptorSigningPrivateKey)
+  );
+
+  return {
+    periodNum,
+    periodLengthMinutes,
+    blindedPrivateKey,
+    blindedPublicKey,
+    blindedSigningKey,
+    subcredential,
+    descriptorSigningPrivateKey,
+    descriptorSigningPublicKey,
+  };
+}
+
+// ============================================================================
+// Introduction point key generation
+// ============================================================================
+
+/**
+ * Generate fresh per-IP key material (auth + enc) for a candidate intro point.
+ * The IP relay's identity comes in via `peerInfo` + `ed25519IdentityKey`.
+ */
+export function generateIntroPointKeys(
+  peerInfo: PeerInfo,
+  ed25519IdentityKey: Buffer
+): IntroductionPoint {
+  const authKeyPrivate = Buffer.from(ed25519.utils.randomPrivateKey());
+  const authKeyPublic = Buffer.from(ed25519.getPublicKey(authKeyPrivate));
+  const encKeyPrivate = Buffer.from(x25519.utils.randomPrivateKey());
+  const encKeyPublic = Buffer.from(x25519.getPublicKey(encKeyPrivate));
+  return {
+    peerInfo,
+    ed25519IdentityKey,
+    authKeyPrivate,
+    authKeyPublic,
+    encKeyPrivate,
+    encKeyPublic,
+    circuit: undefined,
+    established: false,
+  };
+}
+
+// ============================================================================
+// Ed25519 certificate builder (cert-spec.txt §2.1)
+// ============================================================================
+
+/**
+ * Build a proposal-220-format ed25519 certificate.
+ *
+ * Layout: VERSION[1] || CERT_TYPE[1] || EXPIRATION[4] || CERT_KEY_TYPE[1] ||
+ *         CERTIFIED_KEY[32] || N_EXTENSIONS[1] || EXT* || SIG[64].
+ *
+ * `signFn` lets the caller plug in either `ed.sign` (regular seeds) or
+ * {@link signWithBlindedKey} (blinded scalars).
+ */
+function createEd25519Certificate(params: {
+  certType: number;
+  expirationHours: number;
+  certifiedKey: Buffer;
+  certifiedKeyType: number;
+  signingKey: Buffer; // public key of the signer (goes in optional extension)
+  includeSigningKeyExtension: boolean;
+  signFn: (msg: Buffer) => Buffer;
+}): Buffer {
+  const extensions: Buffer[] = [];
+  if (params.includeSigningKeyExtension) {
+    const extData = params.signingKey;
+    const extHeader = Buffer.alloc(4);
+    extHeader.writeUInt16BE(extData.length, 0);
+    extHeader.writeUInt8(EXT_TYPE_SIGNED_WITH_ED25519_KEY, 2);
+    extHeader.writeUInt8(0, 3); // ExtFlags
+    extensions.push(Buffer.concat([extHeader, extData]));
+  }
+
+  const certBody = Buffer.concat([
+    Buffer.from([0x01]), // VERSION
+    Buffer.from([params.certType]),
+    bufferFromUint(4, params.expirationHours),
+    Buffer.from([params.certifiedKeyType]),
+    params.certifiedKey,
+    Buffer.from([extensions.length]),
+    ...extensions,
+  ]);
+
+  const signature = params.signFn(certBody);
+  return Buffer.concat([certBody, signature]);
+}
+
+// ============================================================================
+// Descriptor encryption (rend-spec-v3 §2.5.1.1)
+// ============================================================================
+
+/**
+ * Encrypt a descriptor layer.
+ *
+ * Output: salt[16] || ciphertext || mac[32]. Plaintext is NUL-padded to a
+ * multiple of 10000 bytes before encryption (rend-spec-v3 §2.5.1.1).
+ */
+async function encryptDescriptorLayer(params: {
+  plaintext: Buffer;
+  secretData: Buffer;
+  subcredential: Buffer;
+  revisionCounter: bigint;
+  stringConstant: string;
+}): Promise<Buffer> {
+  const salt = Buffer.from(randomBytes(16));
+
+  const secretInput = Buffer.concat([
+    params.secretData,
+    params.subcredential,
+    u64be(params.revisionCounter),
+  ]);
+
+  const keys = kdfShake256(
+    Buffer.concat([secretInput, salt, Buffer.from(params.stringConstant, 'ascii')]),
+    S_KEY_LEN + S_IV_LEN + MAC_KEY_LEN
+  );
+  const secretKey = keys.subarray(0, S_KEY_LEN);
+  const secretIv = keys.subarray(S_KEY_LEN, S_KEY_LEN + S_IV_LEN);
+  const macKey = keys.subarray(S_KEY_LEN + S_IV_LEN);
+
+  // Pad to nearest multiple of DESCRIPTOR_PADDING_MULTIPLE. If the plaintext
+  // is already a multiple, add zero padding (matches Tor and Arti).
+  const padLen =
+    DESCRIPTOR_PADDING_MULTIPLE - (params.plaintext.length % DESCRIPTOR_PADDING_MULTIPLE);
+  const paddedPlaintext = Buffer.concat([params.plaintext, Buffer.alloc(padLen, 0)]);
+
+  const encrypted = await aes256CtrXor(secretKey, secretIv, paddedPlaintext);
+  const macValue = dMac(macKey, salt, encrypted);
+
+  return Buffer.concat([salt, encrypted, macValue]);
+}
+
+/** Build the link-specifiers block: count[1] || (type[1] || len[1] || data[len])*. */
+function buildLinkSpecifiersBlock(linkSpecifiers: LinkSpecifier[]): Buffer {
+  const parts: Buffer[] = [Buffer.from([linkSpecifiers.length])];
+  for (const ls of linkSpecifiers) {
+    parts.push(Buffer.from([ls.type]));
+    parts.push(Buffer.from([ls.data.length]));
+    parts.push(ls.data);
+  }
+  return Buffer.concat(parts);
+}
+
+function pemBlock(name: string, body: Buffer): string[] {
+  const lines: string[] = [`-----BEGIN ${name}-----`];
+  const b64 = body.toString('base64');
+  for (let i = 0; i < b64.length; i += 64) lines.push(b64.slice(i, i + 64));
+  lines.push(`-----END ${name}-----`);
+  return lines;
+}
+
+// ============================================================================
+// Descriptor plaintext + assembly (rend-spec-v3 §2.5.2)
+// ============================================================================
+
+/**
+ * Build the second-layer (inner) plaintext: a `create2-formats` line plus,
+ * per intro point, an `introduction-point` block with `onion-key`,
+ * `auth-key` cert, `enc-key`, and `enc-key-cert`.
+ *
+ * The intro-point certs are signed by the descriptor signing key (cert
+ * types 0x09 and 0x0b); their certified key is the IP's auth ed25519 key
+ * and the curve25519→ed25519 conversion of the IP's enc key respectively.
+ */
+function generateInnerLayerPlaintext(params: {
+  introPoints: IntroductionPoint[];
+  timePeriodKeys: TimePeriodKeys;
+  certExpirationHours: number;
+}): Buffer {
+  const lines: string[] = [];
+  lines.push('create2-formats 2');
+
+  for (const intro of params.introPoints) {
+    const lsBlock = buildLinkSpecifiersBlock(intro.peerInfo.linkSpecifiers);
+    lines.push(`introduction-point ${lsBlock.toString('base64')}`);
+    lines.push(`onion-key ntor ${intro.peerInfo.onionKey.toString('base64')}`);
+
+    // auth-key cert (type 0x09): certifies the IP's auth ed25519 key,
+    // signed by the descriptor signing key.
+    const authKeyCert = createEd25519Certificate({
+      certType: CERT_TYPE_HS_IP_V_SIGNING,
+      expirationHours: params.certExpirationHours,
+      certifiedKey: intro.authKeyPublic,
+      certifiedKeyType: 0x01, // ed25519
+      signingKey: params.timePeriodKeys.descriptorSigningPublicKey,
+      includeSigningKeyExtension: true,
+      signFn: (msg) => Buffer.from(ed.sign(msg, params.timePeriodKeys.descriptorSigningPrivateKey)),
+    });
+    lines.push('auth-key');
+    lines.push(...pemBlock('ED25519 CERT', authKeyCert));
+
+    lines.push(`enc-key ntor ${intro.encKeyPublic.toString('base64')}`);
+
+    // enc-key-cert (type 0x0b): certifies the ed25519-equivalent of the IP's
+    // curve25519 enc key (proposal 228 appendix A), signed by the descriptor
+    // signing key.
+    const encKeyEd = curve25519PubkeyToEd25519(intro.encKeyPublic);
+    const encKeyCert = createEd25519Certificate({
+      certType: CERT_TYPE_HS_IP_CC_SIGNING,
+      expirationHours: params.certExpirationHours,
+      certifiedKey: encKeyEd,
+      certifiedKeyType: 0x01, // ed25519
+      signingKey: params.timePeriodKeys.descriptorSigningPublicKey,
+      includeSigningKeyExtension: true,
+      signFn: (msg) => Buffer.from(ed.sign(msg, params.timePeriodKeys.descriptorSigningPrivateKey)),
+    });
+    lines.push('enc-key-cert');
+    lines.push(...pemBlock('ED25519 CERT', encKeyCert));
+  }
+
+  return Buffer.from(lines.join('\n') + '\n', 'utf8');
+}
+
+/**
+ * Build the first-layer (outer-encrypted) plaintext.
+ *
+ * Includes:
+ *   - `desc-auth-type x25519` (always present per spec)
+ *   - `desc-auth-ephemeral-key` — a real x25519 pubkey (NOT random bytes)
+ *   - exactly N `auth-client` lines, where N is a multiple of 16 (we use 16
+ *     fakes when client auth is disabled, hiding presence per §2.5.1.2)
+ *   - `encrypted` block containing the second-layer ciphertext
+ */
+function generateFirstLayerPlaintext(innerEncrypted: Buffer): Buffer {
+  // Generate a real ephemeral x25519 keypair so the value is a valid pubkey,
+  // not just random bytes (some verifiers reject malformed pubkeys).
+  const ephPriv = Buffer.from(x25519.utils.randomPrivateKey());
+  const ephPub = Buffer.from(x25519.getPublicKey(ephPriv));
+
+  const lines: string[] = [];
+  lines.push('desc-auth-type x25519');
+  lines.push(`desc-auth-ephemeral-key ${ephPub.toString('base64')}`);
+
+  // Padding to AUTH_CLIENT_PADDING_MULTIPLE entries with random fakes.
+  for (let i = 0; i < AUTH_CLIENT_PADDING_MULTIPLE; i++) {
+    const clientId = Buffer.from(randomBytes(8)).toString('base64').replace(/=+$/, '');
+    const iv = Buffer.from(randomBytes(16)).toString('base64').replace(/=+$/, '');
+    const cookie = Buffer.from(randomBytes(16)).toString('base64').replace(/=+$/, '');
+    lines.push(`auth-client ${clientId} ${iv} ${cookie}`);
+  }
+
+  lines.push('encrypted');
+  lines.push(...pemBlock('MESSAGE', innerEncrypted));
+  return Buffer.from(lines.join('\n') + '\n', 'utf8');
+}
+
+/**
+ * Build a complete v3 hidden-service descriptor as a string.
+ *
+ * The two encrypted layers, descriptor-signing-key cert, and trailing
+ * ed25519 signature line are assembled per rend-spec-v3 §2.5.
+ *
+ * The descriptor body is signed by the descriptor signing key (a fresh
+ * ed25519 keypair); the descriptor signing key cert is in turn signed by
+ * the time-period blinded key via {@link signWithBlindedKey}.
+ */
+export async function generateDescriptor(params: {
+  keys: HiddenServiceKeys;
+  timePeriodKeys: TimePeriodKeys;
+  introPoints: IntroductionPoint[];
+  revisionCounter: bigint;
+  /** Cert expiration in hours-since-epoch (default: now + 7d). */
+  certExpirationHours?: number;
+  /** Descriptor lifetime in minutes (default 180 = 3h, the spec maximum). */
+  descriptorLifetimeMinutes?: number;
+}): Promise<string> {
+  const { timePeriodKeys, introPoints, revisionCounter } = params;
+  const certExpirationHours =
+    params.certExpirationHours ?? Math.floor(Date.now() / (60 * 60 * 1000)) + 24 * 7;
+  const descriptorLifetimeMinutes = params.descriptorLifetimeMinutes ?? 180;
+
+  const innerPlaintext = generateInnerLayerPlaintext({
+    introPoints,
+    timePeriodKeys,
+    certExpirationHours,
+  });
+  const innerEncrypted = await encryptDescriptorLayer({
+    plaintext: innerPlaintext,
+    secretData: timePeriodKeys.blindedPublicKey,
+    subcredential: timePeriodKeys.subcredential,
+    revisionCounter,
+    stringConstant: 'hsdir-encrypted-data',
+  });
+
+  const firstLayerPlaintext = generateFirstLayerPlaintext(innerEncrypted);
+  const superencrypted = await encryptDescriptorLayer({
+    plaintext: firstLayerPlaintext,
+    secretData: timePeriodKeys.blindedPublicKey,
+    subcredential: timePeriodKeys.subcredential,
+    revisionCounter,
+    stringConstant: 'hsdir-superencrypted-data',
+  });
+
+  const lines: string[] = [];
+  lines.push('hs-descriptor 3');
+  lines.push(`descriptor-lifetime ${descriptorLifetimeMinutes}`);
+
+  // descriptor-signing-key-cert (cert type 0x08): signed by the BLINDED key.
+  const signingKeyCert = createEd25519Certificate({
+    certType: CERT_TYPE_HS_BLINDED_ID_V_SIGNING,
+    expirationHours: certExpirationHours,
+    certifiedKey: timePeriodKeys.descriptorSigningPublicKey,
+    certifiedKeyType: 0x01,
+    signingKey: timePeriodKeys.blindedPublicKey,
+    includeSigningKeyExtension: true,
+    signFn: (msg) =>
+      signWithBlindedKey(msg, timePeriodKeys.blindedSigningKey, timePeriodKeys.blindedPublicKey),
+  });
+  lines.push('descriptor-signing-key-cert');
+  lines.push(...pemBlock('ED25519 CERT', signingKeyCert));
+
+  lines.push(`revision-counter ${revisionCounter}`);
+
+  lines.push('superencrypted');
+  lines.push(...pemBlock('MESSAGE', superencrypted));
+
+  // Sign the descriptor body with the descriptor signing key. The signed
+  // input is "Tor onion service descriptor sig v3" || body, where body is
+  // everything BEFORE the trailing "signature" line (rend-spec-v3 §2.5.4).
+  const descriptorBody = lines.join('\n') + '\n';
+  const sigInput = Buffer.concat([
+    Buffer.from('Tor onion service descriptor sig v3', 'ascii'),
+    Buffer.from(descriptorBody, 'utf8'),
+  ]);
+  const signature = Buffer.from(ed.sign(sigInput, timePeriodKeys.descriptorSigningPrivateKey));
+  lines.push('signature ' + signature.toString('base64'));
+
+  return lines.join('\n') + '\n';
+}
+
+// ============================================================================
+// ESTABLISH_INTRO (rend-spec-v3 §3.1.1)
+// ============================================================================
+
+/**
+ * Build the body of an ESTABLISH_INTRO cell (extensible / "v1" format).
+ *
+ * Layout:
+ *   AUTH_KEY_TYPE   [1] = 0x02 (Ed25519)
+ *   AUTH_KEY_LEN    [2]
+ *   AUTH_KEY        [AUTH_KEY_LEN]
+ *   N_EXTENSIONS    [1]
+ *   EXTENSIONS      [variable]
+ *   HANDSHAKE_AUTH  [MAC_LEN=32 bytes] = MAC(circuitMacKey, body-so-far)
+ *   SIG_LEN         [2 bytes]
+ *   SIG             [SIG_LEN bytes]   ed25519 signature with auth key
+ *
+ * `circuitMacKey` MUST be the last hop's ntor KH (`Circuit.getLastHopNtorKh()`)
+ * — anything else and the IP relay will reject the cell. SIG signs
+ * "Tor establish-intro cell v1" || (every byte from AUTH_KEY_TYPE through
+ * HANDSHAKE_AUTH inclusive).
+ */
+export function buildEstablishIntroPayload(params: {
+  authKeyPublic: Buffer;
+  authKeyPrivate: Buffer;
+  circuitMacKey: Buffer;
+}): Buffer {
+  const AUTH_KEY_TYPE_ED25519 = 0x02;
+
+  // Pre-MAC body: AUTH_KEY_TYPE || AUTH_KEY_LEN || AUTH_KEY || N_EXTENSIONS
+  const body = Buffer.concat([
+    Buffer.from([AUTH_KEY_TYPE_ED25519]),
+    bufferFromUint(2, params.authKeyPublic.length),
+    params.authKeyPublic,
+    Buffer.from([0x00]), // N_EXTENSIONS = 0
+  ]);
+
+  // HANDSHAKE_AUTH = MAC(circuitMacKey, body)
+  const handshakeAuth = mac(params.circuitMacKey, body);
+
+  // SIG signs "Tor establish-intro cell v1" || body || HANDSHAKE_AUTH.
+  const toSign = Buffer.concat([
+    Buffer.from('Tor establish-intro cell v1', 'ascii'),
+    body,
+    handshakeAuth,
+  ]);
+  const signature = Buffer.from(ed.sign(toSign, params.authKeyPrivate));
+
+  // Cell payload: body || HANDSHAKE_AUTH || SIG_LEN || SIG
+  return Buffer.concat([body, handshakeAuth, bufferFromUint(2, signature.length), signature]);
+}
+
+// ============================================================================
+// INTRODUCE2 (rend-spec-v3 §3.3) — server side
+// ============================================================================
+
+/**
+ * Parse an INTRODUCE2 payload into its raw fields. Does no crypto; pure
+ * structural parsing that mirrors the client's INTRODUCE1 layout.
+ *
+ *   LEGACY_KEY_ID  [20] (zeros for v3)
+ *   AUTH_KEY_TYPE  [1] = 0x02
+ *   AUTH_KEY_LEN   [2] = 32
+ *   AUTH_KEY       [32]
+ *   N_EXTENSIONS   [1]
+ *   EXTENSIONS     [variable]   (each: type[1] len[1] data[len])
+ *   CLIENT_PK      [32]
+ *   ENCRYPTED      [variable, includes trailing 32-byte MAC]
+ */
+export function parseIntroduce2(payload: Buffer): Introduce2Parsed {
+  const reader = new BytesReader(payload);
+  reader.readBytes(20); // LEGACY_KEY_ID
+
+  const authKeyType = reader.readUIntBE(1);
+  if (authKeyType !== 0x02) {
+    throw new Error(`Unexpected INTRODUCE2 auth key type: ${authKeyType}`);
+  }
+  const authKeyLen = reader.readUIntBE(2);
+  if (authKeyLen !== 32) {
+    throw new Error(`Unexpected INTRODUCE2 auth key length: ${authKeyLen}`);
+  }
+  const authKey = reader.readBytes(32);
+
+  const nExtensions = reader.readUIntBE(1);
+  for (let i = 0; i < nExtensions; i++) {
+    const extType = reader.readUIntBE(1);
+    void extType;
+    const extLen = reader.readUIntBE(1);
+    reader.readBytes(extLen);
+  }
+
+  const clientPk = reader.readBytes(32);
+  const tail = reader.readRemainder();
+  if (tail.length < 32) throw new Error('INTRODUCE2 trailing data too short for MAC');
+
+  const encryptedData = tail.subarray(0, tail.length - 32);
+  const macValue = tail.subarray(tail.length - 32);
+
+  return { authKey, clientPk, encryptedData, macValue };
+}
+
+/**
+ * Decrypt and authenticate an INTRODUCE2 payload, returning the rendezvous
+ * cookie + rendezvous-point info the client placed inside.
+ *
+ * Mirrors the client's hs-ntor INTRODUCE1 encryption: shared secret is
+ * `EXP(b, X)` (server enc-key private × client ephemeral pub); KDF is the
+ * same SHAKE256 used in {@link encryptDescriptorLayer}; MAC must match the
+ * trailing 32 bytes of the INTRODUCE2 payload.
+ */
+export async function decryptIntroduce2(params: {
+  parsed: Introduce2Parsed;
+  introPoint: IntroductionPoint;
+  subcredential: Buffer;
+}): Promise<Introduce2Decrypted> {
+  const { parsed, introPoint, subcredential } = params;
+
+  const t_hsenc = Buffer.from(`${HS_NTOR_PROTOID.toString('ascii')}:hs_key_extract`, 'ascii');
+  const m_hsexpand = Buffer.from(`${HS_NTOR_PROTOID.toString('ascii')}:hs_key_expand`, 'ascii');
+
+  // EXP(X, b): server enc-key private × client ephemeral pub
+  const expXb = Buffer.from(x25519.scalarMult(introPoint.encKeyPrivate, parsed.clientPk));
+
+  const introSecret = Buffer.concat([
+    expXb,
+    parsed.authKey,
+    parsed.clientPk,
+    introPoint.encKeyPublic,
+    HS_NTOR_PROTOID,
+  ]);
+
+  const info = Buffer.concat([m_hsexpand, subcredential]);
+  const keys = kdfShake256(Buffer.concat([introSecret, t_hsenc, info]), S_KEY_LEN + MAC_KEY_LEN);
+  const encKey = keys.subarray(0, S_KEY_LEN);
+  const macKey = keys.subarray(S_KEY_LEN);
+
+  // MAC covers everything from LEGACY_KEY_ID through ENCRYPTED (rend-spec-v3
+  // §3.3.2). Reconstruct that input from parsed fields.
+  const macInput = Buffer.concat([
+    Buffer.alloc(20), // LEGACY_KEY_ID
+    Buffer.from([0x02]), // AUTH_KEY_TYPE
+    Buffer.from([0x00, 0x20]), // AUTH_KEY_LEN
+    parsed.authKey,
+    Buffer.from([0x00]), // N_EXT
+    parsed.clientPk,
+    parsed.encryptedData,
+  ]);
+  const expected = mac(macKey, macInput);
+  if (!expected.equals(parsed.macValue)) {
+    throw new Error('INTRODUCE2 MAC verification failed');
+  }
+
+  const iv0 = Buffer.alloc(16, 0);
+  const decrypted = await aes256CtrXor(encKey, iv0, parsed.encryptedData);
+
+  const r = new BytesReader(decrypted);
+  const rendezvousCookie = r.readBytes(20);
+
+  const nExt = r.readUIntBE(1);
+  for (let i = 0; i < nExt; i++) {
+    r.readUIntBE(1);
+    const extLen = r.readUIntBE(1);
+    r.readBytes(extLen);
+  }
+
+  const onionKeyType = r.readUIntBE(1);
+  const onionKeyLen = r.readUIntBE(2);
+  const onionKey = r.readBytes(onionKeyLen);
+
+  const nLs = r.readUIntBE(1);
+  const linkSpecifiers: LinkSpecifier[] = [];
+  for (let i = 0; i < nLs; i++) {
+    const lsType = r.readUIntBE(1);
+    const lsLen = r.readUIntBE(1);
+    const lsData = r.readBytes(lsLen);
+    linkSpecifiers.push({ type: lsType, data: lsData });
+  }
+
+  return { rendezvousCookie, onionKeyType, onionKey, linkSpecifiers };
+}
+
+// ============================================================================
+// hs-ntor server side (rend-spec-v3 §4.2)
+// ============================================================================
+
+/**
+ * Complete the hs-ntor handshake from the server's perspective and produce
+ * the RENDEZVOUS1 payload + the rendezvous-circuit cipher pair.
+ *
+ * The cipher pair is intentionally swapped relative to the client:
+ *   - client side `forward` = client→service; the service receives those.
+ *   - client side `backward` = service→client; the service writes those.
+ *
+ * That means the host stores `cipherPair.forward = client's backward`,
+ * `cipherPair.backward = client's forward`, so `Circuit.encryptForward` /
+ * `decryptBackward` line up with what the client's virtual hop expects.
+ */
+export function completeHsNtorServer(params: {
+  /** X — the client's ephemeral curve25519 pubkey from the INTRODUCE2 cell. */
+  clientPk: Buffer;
+  introPoint: IntroductionPoint;
+  subcredential: Buffer;
+}): { rendezvous1Data: Buffer; cipherPair: CircuitCipherPair } {
+  const { clientPk, introPoint } = params;
+
+  const y = Buffer.from(x25519.utils.randomPrivateKey());
+  const Y = Buffer.from(x25519.getPublicKey(y));
+
+  const t_hsenc = Buffer.from(`${HS_NTOR_PROTOID.toString('ascii')}:hs_key_extract`, 'ascii');
+  const t_hsverify = Buffer.from(`${HS_NTOR_PROTOID.toString('ascii')}:hs_verify`, 'ascii');
+  const t_hsmac = Buffer.from(`${HS_NTOR_PROTOID.toString('ascii')}:hs_mac`, 'ascii');
+  const m_hsexpand = Buffer.from(`${HS_NTOR_PROTOID.toString('ascii')}:hs_key_expand`, 'ascii');
+
+  const expXy = Buffer.from(x25519.scalarMult(y, clientPk));
+  const expXb = Buffer.from(x25519.scalarMult(introPoint.encKeyPrivate, clientPk));
+
+  const rendSecret = Buffer.concat([
+    expXy,
+    expXb,
+    introPoint.authKeyPublic,
+    introPoint.encKeyPublic,
+    clientPk,
+    Y,
+    HS_NTOR_PROTOID,
+  ]);
+
+  const NTOR_KEY_SEED = mac(rendSecret, t_hsenc);
+  const verify = mac(rendSecret, t_hsverify);
+  const authInput = Buffer.concat([
+    verify,
+    introPoint.authKeyPublic,
+    introPoint.encKeyPublic,
+    Y,
+    clientPk,
+    HS_NTOR_PROTOID,
+    Buffer.from('Server', 'ascii'),
+  ]);
+  const AUTH = mac(authInput, t_hsmac);
+
+  const rendezvous1Data = Buffer.concat([Y, AUTH]);
+
+  // KDF for rendezvous circuit cipher pair. Same shape as the client's
+  // makeHsRendezvousCipherPairFromKeySeed but with the directions swapped.
+  const K = kdfShake256(
+    Buffer.concat([NTOR_KEY_SEED, m_hsexpand]),
+    HASH_LEN * 2 + S_KEY_LEN * 2
+  );
+  const reader = new BytesReader(K);
+  const fSeed = reader.readBytes(HASH_LEN);
+  const bSeed = reader.readBytes(HASH_LEN);
+  const Kf = reader.readBytes(S_KEY_LEN);
+  const Kb = reader.readBytes(S_KEY_LEN);
+
+  const forwardDigest = createSha3_256Hash();
+  const backwardDigest = createSha3_256Hash();
+  forwardDigest.update(fSeed);
+  backwardDigest.update(bSeed);
+
+  const forwardKey = makeAes256CtrKey(Kf);
+  const backwardKey = makeAes256CtrKey(Kb);
+
+  // Swap forward/backward: from the service's POV, what the client sends as
+  // "forward" is what we receive as "backward" and vice versa.
+  const cipherPair: CircuitCipherPair = {
+    forward: { key: backwardKey, digest: backwardDigest },
+    backward: { key: forwardKey, digest: forwardDigest },
+  };
+
+  return { rendezvous1Data, cipherPair };
+}
+
+// ============================================================================
+// HiddenServiceHost — control surface
+// ============================================================================
+
+/**
+ * Wait for the next relay cell on `circuit` matching `relayCommand`.
+ * Resolves with the cell or rejects on timeout / circuit destruction.
+ */
+async function waitForRelayCommand(
+  circuit: Circuit,
+  relayCommand: number,
+  timeoutMs: number
+): Promise<{ streamId: number; relayCommand: number; data: Buffer }> {
+  return await new Promise((resolve, reject) => {
+    let settled = false;
+    const cleanup = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      circuit.off('relay', onRelay);
+      circuit.off('destroyed', onDestroyed);
+    };
+    const onRelay = (evt: { streamId: number; relayCommand: number; data: Buffer }) => {
+      if (evt.relayCommand !== relayCommand) return;
+      cleanup();
+      resolve(evt);
+    };
+    const onDestroyed = () => {
+      cleanup();
+      reject(new Error(`Circuit destroyed while waiting for relayCommand=${relayCommand}`));
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for relayCommand=${relayCommand}`));
+    }, timeoutMs);
+    circuit.on('relay', onRelay);
+    circuit.once('destroyed', onDestroyed);
+  });
+}
+
+/**
+ * Look up the rendezvous-point relay's full PeerInfo (onion key + Ed25519 id)
+ * given the link specifiers the client sent inside INTRODUCE2.
+ *
+ * The link specifiers always include the legacy RSA identity digest; we use
+ * that to locate the relay in the consensus and then `lookupPeerInfo` to
+ * fetch its server descriptor (for ntor onion key + Ed25519 identity).
+ *
+ * Falls back to a stripped peer if the consensus / directory lookup fails;
+ * the caller will then fail at circuit-extension time with a clearer error.
+ */
+async function rendezvousPointPeerInfo(
+  linkSpecifiers: LinkSpecifier[],
+  consensus: VerifiedMicroDescConsensus,
+  dirClient: DirectoryClient
+): Promise<PeerInfo> {
+  const legacyId = linkSpecifiers.find((ls) => ls.type === LinkSpecifierTypes.LegacyId);
+  if (!legacyId) {
+    throw new Error('Rendezvous point link specifiers missing legacy identity');
+  }
+  const rsaIdHex = legacyId.data.toString('hex');
+  const node = consensus.relays.find(
+    (r: MicroDescNodeInfo) => r.rsaIdDigest.toString('hex') === rsaIdHex
+  );
+  if (!node) {
+    throw new Error(`Rendezvous point ${rsaIdHex.slice(0, 8)} not in consensus`);
+  }
+  return await lookupPeerInfo(dirClient, node);
+}
+
+/**
+ * The HiddenServiceHost orchestrates the server side of a v3 onion service
+ * over the Chutney test network: bootstrap → pick + establish intro points
+ * → publish descriptor → handle INTRODUCE2 → complete rendezvous.
+ *
+ * Application code subscribes to the `'rendezvous'` event to receive the
+ * rendezvous Circuit (with the virtual hop already added) and is then
+ * responsible for handling incoming RELAY_BEGIN / RELAY_DATA / RELAY_END
+ * cells per its application protocol.
+ *
+ * NOTE: the descriptor refresh / rotate-on-time-period machinery is
+ * deliberately minimal. It re-uploads on a 30-minute timer, which is fine
+ * for the chutney integration test but a real deployment would want to
+ * key rotation off the consensus's `valid-after` boundaries.
+ */
+export class HiddenServiceHost extends EventEmitter {
+  readonly keys: HiddenServiceKeys;
+  private timePeriodKeys: TimePeriodKeys | undefined;
+  private introPoints: IntroductionPoint[] = [];
+  private revisionCounter: bigint = 0n;
+  private running = false;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private torClient: TorClient<any> | undefined;
+  private refreshInterval: ReturnType<typeof setInterval> | undefined;
+  private log: (msg: string) => void;
+
+  constructor(keys?: HiddenServiceKeys, options: { log?: (msg: string) => void } = {}) {
+    super();
+    this.keys = keys ?? generateHiddenServiceKeys();
+    this.log = options.log ?? ((msg) => console.log(`[hs-host] ${msg}`));
+  }
+
+  get onionAddress(): string {
+    return this.keys.onionAddress;
+  }
+
+  /**
+   * Start the hidden service over a {@link TorClient}. Bootstraps from the
+   * client's already-established consensus + bootstrap circuit, picks +
+   * establishes `numIntroPoints` introduction points, and uploads the
+   * descriptor to ~6 HSDirs.
+   *
+   * Works for any TorClient implementation — chutney, mainnet, or
+   * Snowflake-backed browser.
+   */
+  async start(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    torClient: TorClient<any>,
+    options: {
+      numIntroPoints?: number;
+      perStepTimeoutMs?: number;
+      descriptorRefreshMs?: number;
+    } = {}
+  ): Promise<void> {
+    const numIntroPoints = options.numIntroPoints ?? 3;
+    const perStepTimeoutMs = options.perStepTimeoutMs ?? 120_000;
+    const descriptorRefreshMs = options.descriptorRefreshMs ?? 30 * 60 * 1000;
+
+    if (this.running) throw new Error('Hidden service is already running');
+
+    this.torClient = torClient;
+    this.log(`starting hidden service ${this.keys.onionAddress}`);
+
+    const consensus = torClient.consensus;
+    if (!consensus.validAfter) {
+      throw new Error('TorClient consensus missing valid-after');
+    }
+
+    // 1. Derive descriptor key bundle for this consensus's time window.
+    const tpArgs: Parameters<typeof deriveTimePeriodKeys>[0] = {
+      keys: this.keys,
+      validAfter: consensus.validAfter,
+    };
+    if (consensus.freshUntil) tpArgs.freshUntil = consensus.freshUntil;
+    this.timePeriodKeys = deriveTimePeriodKeys(tpArgs);
+
+    // 2. Pick + establish intro points. Mainnet relays advertise rich flag
+    //    sets; chutney's tiny network usually only has Running+Stable, so we
+    //    accept any relay with Stable+Running and exclude obvious non-IPs.
+    const introCandidates = consensus.relays.filter((r) => {
+      const flags = r.flags ?? [];
+      if (flags.includes('BadExit')) return false;
+      if (flags.includes('Authority')) return false;
+      return flags.includes('Stable') && flags.includes('Running');
+    });
+    if (introCandidates.length === 0) {
+      throw new Error('No suitable introduction-point candidates in consensus');
+    }
+
+    const used: MicroDescNodeInfo[] = [];
+    for (let i = 0; i < numIntroPoints && used.length < introCandidates.length; i++) {
+      const relay = pickRelayWithFlags(introCandidates, [], used);
+      used.push(relay);
+      try {
+        const { peerInfo, ed25519IdentityKey } = await lookupPeerInfoWithEd25519IdentityKey(
+          torClient.dirClient,
+          relay
+        );
+        const intro = generateIntroPointKeys(peerInfo, ed25519IdentityKey);
+        await this.establishIntroPoint(intro, perStepTimeoutMs);
+        this.introPoints.push(intro);
+      } catch (err) {
+        this.log(
+          `intro point ${relay.nickname} failed: ${err instanceof Error ? err.message : err}`
+        );
+      }
+    }
+    if (this.introPoints.filter((i) => i.established).length === 0) {
+      throw new Error('Failed to establish any introduction points');
+    }
+    this.log(`established ${this.introPoints.length} introduction points`);
+
+    // 3. Upload the descriptor.
+    await this.uploadDescriptor();
+
+    this.running = true;
+    this.refreshInterval = setInterval(() => {
+      this.uploadDescriptor().catch((err) =>
+        this.log(`descriptor refresh failed: ${err instanceof Error ? err.message : err}`)
+      );
+    }, descriptorRefreshMs);
+    this.refreshInterval.unref?.();
+
+    this.log(`running at ${this.keys.onionAddress}`);
+  }
+
+  /** Number of intro points whose ESTABLISH_INTRO is currently acknowledged. */
+  numActiveIntroPoints(): number {
+    return this.introPoints.filter((i) => i.established && !i.circuit?.isDestroyed).length;
+  }
+
+  /**
+   * Build a 3-hop circuit terminating at `intro`, send ESTABLISH_INTRO using
+   * the last hop's ntor KH as MAC_KEY, and arm an INTRODUCE2 listener.
+   */
+  private async establishIntroPoint(
+    intro: IntroductionPoint,
+    timeoutMs: number
+  ): Promise<void> {
+    if (!this.torClient) {
+      throw new Error('Hidden service not bootstrapped (torClient missing)');
+    }
+
+    const introCircuit = await this.torClient.buildCircuitToTarget(intro.peerInfo);
+    intro.circuit = introCircuit;
+
+    const circuitMacKey = introCircuit.getLastHopNtorKh();
+    const payload = buildEstablishIntroPayload({
+      authKeyPublic: intro.authKeyPublic,
+      authKeyPrivate: intro.authKeyPrivate,
+      circuitMacKey,
+    });
+
+    await introCircuit.sendRelayMessage({
+      streamId: 0,
+      relayCommand: RelayCell.ESTABLISH_INTRO,
+      data: payload,
+    });
+
+    await waitForRelayCommand(introCircuit, RelayCell.INTRO_ESTABLISHED, timeoutMs);
+    intro.established = true;
+
+    // Wire up the INTRODUCE2 handler. We don't await — INTRODUCE2 cells are
+    // unsolicited from our POV. Errors are logged but don't tear down the IP.
+    introCircuit.on('relay', (evt) => {
+      if (evt.relayCommand === RelayCell.INTRODUCE2) {
+        this.handleIntroduce2(intro, evt.data).catch((err) => {
+          this.log(`INTRODUCE2 handling failed: ${err instanceof Error ? err.message : err}`);
+          this.emit('introduce2-error', err);
+        });
+      }
+    });
+  }
+
+  /**
+   * Build, sign, and POST the descriptor to the first ~6 HSDirs in the
+   * consensus. Increments `revisionCounter` so refreshes look fresh.
+   */
+  private async uploadDescriptor(): Promise<void> {
+    if (!this.timePeriodKeys || !this.torClient) {
+      throw new Error('Hidden service not initialized');
+    }
+
+    const established = this.introPoints.filter((i) => i.established);
+    if (established.length === 0) {
+      this.log('no established intro points; skipping descriptor upload');
+      return;
+    }
+
+    this.revisionCounter++;
+    const descriptor = await generateDescriptor({
+      keys: this.keys,
+      timePeriodKeys: this.timePeriodKeys,
+      introPoints: established,
+      revisionCounter: this.revisionCounter,
+    });
+    this.log(`descriptor generated (rev ${this.revisionCounter}, ${descriptor.length} bytes)`);
+
+    const consensus = this.torClient.consensus;
+    const hsdirNodes = consensus.relays.filter((r) => (r.flags ?? []).includes('HSDir'));
+    if (hsdirNodes.length === 0) {
+      this.log('no HSDir nodes in consensus; cannot publish');
+      return;
+    }
+
+    let uploads = 0;
+    for (const hsdir of hsdirNodes.slice(0, 6)) {
+      try {
+        const peerInfo = await lookupPeerInfo(this.torClient.dirClient, hsdir);
+        const circuit = await this.torClient.buildCircuitToTarget(peerInfo);
+
+        const stream = await circuit.openDirectoryStream();
+        const body = Buffer.from(descriptor, 'utf8');
+        const request = Buffer.from(
+          `POST /tor/hs/3/publish HTTP/1.0\r\n` +
+            `Host: hsdir\r\n` +
+            `Content-Type: text/plain\r\n` +
+            `Content-Length: ${body.length}\r\n` +
+            `\r\n`,
+          'ascii'
+        );
+        await stream.write(Buffer.concat([request, body]));
+
+        const responseChunks: Buffer[] = [];
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(() => {
+            stream.off('data', onData);
+            stream.off('end', onEnd);
+            reject(new Error('descriptor upload timeout'));
+          }, 30_000);
+          const onData = (d: Buffer) => responseChunks.push(Buffer.from(d));
+          const onEnd = () => {
+            clearTimeout(timer);
+            resolve();
+          };
+          stream.on('data', onData);
+          stream.once('end', onEnd);
+        });
+
+        const responseText = Buffer.concat(responseChunks).toString('utf8');
+        if (responseText.startsWith('HTTP/') && responseText.includes(' 200 ')) {
+          uploads++;
+          this.log(`uploaded to HSDir ${hsdir.nickname}`);
+        } else {
+          this.log(`HSDir ${hsdir.nickname} rejected: ${responseText.split('\r\n')[0] ?? '(no response)'}`);
+        }
+        circuit.destroy();
+      } catch (err) {
+        this.log(
+          `HSDir ${hsdir.nickname} upload failed: ${err instanceof Error ? err.message : err}`
+        );
+      }
+    }
+    this.log(`descriptor uploaded to ${uploads}/${Math.min(6, hsdirNodes.length)} HSDirs`);
+  }
+
+  /**
+   * Handle a single INTRODUCE2 cell: parse + decrypt, build a circuit to
+   * the rendezvous point, send RENDEZVOUS1 with the cipher pair derived
+   * from hs-ntor, attach the virtual hop, and emit `'rendezvous'` to the
+   * application.
+   *
+   * After the rendezvous circuit is up, BEGIN cells from the client are
+   * intercepted, server-side {@link CircuitStream} objects are allocated
+   * and CONNECTED is sent, and each accepted stream is emitted as
+   * `'connection'` for the application.
+   */
+  private async handleIntroduce2(intro: IntroductionPoint, data: Buffer): Promise<void> {
+    if (!this.timePeriodKeys || !this.torClient) {
+      throw new Error('Hidden service not initialized');
+    }
+
+    const parsed = parseIntroduce2(data);
+    const decrypted = await decryptIntroduce2({
+      parsed,
+      introPoint: intro,
+      subcredential: this.timePeriodKeys.subcredential,
+    });
+
+    const rendPeer = await rendezvousPointPeerInfo(
+      decrypted.linkSpecifiers,
+      this.torClient.consensus,
+      this.torClient.dirClient
+    );
+
+    const rendCircuit = await this.torClient.buildCircuitToTarget(rendPeer);
+
+    const { rendezvous1Data, cipherPair } = completeHsNtorServer({
+      clientPk: parsed.clientPk,
+      introPoint: intro,
+      subcredential: this.timePeriodKeys.subcredential,
+    });
+
+    await rendCircuit.sendRelayMessage({
+      streamId: 0,
+      relayCommand: RelayCell.RENDEZVOUS1,
+      data: Buffer.concat([decrypted.rendezvousCookie, rendezvous1Data]),
+    });
+    rendCircuit.addVirtualHop(cipherPair);
+
+    this.log('rendezvous complete; arming BEGIN handler');
+    this.attachServerSideStreamHandler(rendCircuit);
+    this.emit('rendezvous', { circuit: rendCircuit });
+  }
+
+  /**
+   * Intercept BEGIN cells on a rendezvous circuit and surface each as a
+   * server-side {@link CircuitStream}. The stream's `write()` is overridden
+   * to short-circuit the client-side flow-control machinery and send DATA
+   * cells directly via the circuit's last (virtual) hop.
+   */
+  private attachServerSideStreamHandler(circuit: Circuit): void {
+    const acceptStreamId = (streamId: number, destination: string): CircuitStream | undefined => {
+      // Reject if a stream with this id already exists (replay or buggy peer).
+      if (circuit.streams.some((s) => s.streamId === streamId)) return undefined;
+
+      const stream = new CircuitStream();
+      stream.streamId = streamId;
+      stream.destination = destination;
+      stream.write = async (data: Buffer) => {
+        await circuit.sendRelayMessage({
+          streamId,
+          relayCommand: RelayCell.DATA,
+          data,
+        });
+      };
+      // The connectionLatch is a client-side artifact; pre-resolve it so the
+      // existing CONNECTED handler in Circuit.receiveRelayMessage doesn't
+      // throw if a stray CONNECTED arrives, and so application code that
+      // does `await stream.write(...)` doesn't deadlock waiting on it.
+      stream.connectionLatch.resolve();
+      circuit.streams.push(stream);
+      return stream;
+    };
+
+    circuit.on(
+      'relay',
+      (evt: { streamId: number; relayCommand: number; data: Buffer }) => {
+        if (evt.relayCommand !== RelayCell.BEGIN) return;
+        // BEGIN body: <addr:port>\0<flags 4 bytes>
+        const nul = evt.data.indexOf(0);
+        if (nul < 0) {
+          this.log(`BEGIN streamId=${evt.streamId} missing NUL terminator`);
+          return;
+        }
+        const addrPort = evt.data.subarray(0, nul).toString('ascii');
+        const lastColon = addrPort.lastIndexOf(':');
+        const portStr = lastColon >= 0 ? addrPort.slice(lastColon + 1) : addrPort;
+        const port = Number.parseInt(portStr, 10);
+
+        if (!this.acceptPort(port)) {
+          this.log(`refusing BEGIN streamId=${evt.streamId} for port=${port} (filtered)`);
+          // Reject with REASON_NOTDIRECTORY (6) — generic "we don't want this".
+          circuit.sendRelayMessage({
+            streamId: evt.streamId,
+            relayCommand: RelayCell.END,
+            data: Buffer.from([6]),
+          }).catch(() => undefined);
+          return;
+        }
+
+        const stream = acceptStreamId(evt.streamId, addrPort);
+        if (!stream) return;
+
+        // Send CONNECTED (8 zero bytes = no IPv4 + ttl=0) to accept.
+        circuit
+          .sendRelayMessage({
+            streamId: evt.streamId,
+            relayCommand: RelayCell.CONNECTED,
+            data: Buffer.alloc(8),
+          })
+          .then(() => {
+            // Hand the accepted stream to the application.
+            this.emit('connection', stream);
+            // Also forward to the per-host onConnection callback if set.
+            this.onConnectionCallback?.(stream);
+          })
+          .catch((err) => {
+            this.log(
+              `failed to send CONNECTED for stream ${evt.streamId}: ${err instanceof Error ? err.message : err}`
+            );
+            stream.destroy(err instanceof Error ? err : new Error(String(err)));
+          });
+      }
+    );
+  }
+
+  /**
+   * Test whether to accept a BEGIN cell for a given destination port.
+   * Default: accept everything; overridden via constructor options.
+   */
+  private acceptPort: (port: number) => boolean = () => true;
+  private onConnectionCallback: ((stream: CircuitStream) => void) | undefined;
+
+  /**
+   * Override the port-accept policy. Called by the {@link publishHiddenService}
+   * factory to enforce the user's `port` setting.
+   */
+  setAcceptPort(fn: (port: number) => boolean): void {
+    this.acceptPort = fn;
+  }
+
+  /** Set the per-stream connection callback (used by {@link publishHiddenService}). */
+  setOnConnection(cb: (stream: CircuitStream) => void): void {
+    this.onConnectionCallback = cb;
+  }
+
+  /**
+   * Tear down all intro circuits + timers and resolve. Idempotent; never
+   * rejects. The injected TorClient is NOT destroyed — the caller owns it.
+   */
+  async unpublish(): Promise<void> {
+    if (!this.running && this.introPoints.length === 0 && !this.refreshInterval) return;
+    this.log('stopping hidden service');
+    this.running = false;
+    if (this.refreshInterval) {
+      clearInterval(this.refreshInterval);
+      this.refreshInterval = undefined;
+    }
+    for (const intro of this.introPoints) {
+      try {
+        intro.circuit?.destroy();
+      } catch {
+        // best-effort
+      }
+    }
+    this.introPoints = [];
+    this.torClient = undefined;
+    this.emit('stopped');
+  }
+
+  /** Synchronous alias for {@link unpublish} (kept for backward-compat). */
+  stop(): void {
+    void this.unpublish();
+  }
+}
+
+// ============================================================================
+// Test helpers (re-exports)
+// ============================================================================
+//
+// These are private to the module but exposed for the spec tests so we can
+// assert on the small primitives (matching the surface PR #21 had).
+
+export {
+  sha3,
+  mac,
+  dMac,
+  kdfShake256,
+  base32EncodeLowerNoPad,
+  curve25519PubkeyToEd25519,
+  encryptDescriptorLayer,
+  createEd25519Certificate,
+};
+
+// ============================================================================
+// publishHiddenService — high-level factory matching HS-HOST-API.md
+// ============================================================================
+
+/** Options for {@link publishHiddenService}. */
+export interface PublishHiddenServiceOptions {
+  /**
+   * Bootstrapped TorClient (mainnet, chutney, or browser/Snowflake).
+   * Typed as `TorClient<any>` so concrete clients with narrower channel
+   * types (e.g. `TorClient<TlsChannelConnection>`) can be passed without a
+   * cast — the host only uses the channel-agnostic surface
+   * (`consensus`, `dirClient`, `buildCircuitToTarget`).
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  torClient: TorClient<any>;
+  /** Virtual port the onion service will accept BEGIN cells for. */
+  port: number;
+  /** Called once per accepted incoming stream (one per BEGIN). */
+  onConnection: (stream: CircuitStream) => void;
+  /**
+   * 32-byte ed25519 seed that pins the .onion address. If omitted a fresh
+   * identity is generated; the caller can persist `host.identityKey`.
+   */
+  identityKey?: Buffer | Uint8Array;
+  /** Number of intro points to maintain (default 3). */
+  numIntroPoints?: number;
+  /** How often to republish the descriptor (default 30 minutes). */
+  descriptorRefreshMs?: number;
+  /** Per-step timeout for circuit / handshake operations (default 120s). */
+  perStepTimeoutMs?: number;
+  log?: (msg: string) => void;
+}
+
+/** Handle returned by {@link publishHiddenService}. */
+export interface HsHost {
+  readonly onion: string;
+  readonly identityKey: Uint8Array;
+  numActiveIntroPoints(): number;
+  unpublish(): Promise<void>;
+}
+
+/**
+ * Publish a v3 onion service over a {@link TorClient} and surface inbound
+ * BEGIN-streams to the application via `onConnection`.
+ *
+ * Resolves once at least one introduction point is established AND the
+ * descriptor has been uploaded to at least one HSDir (the host's start()
+ * method enforces that invariant before resolving). Errors during steady
+ * state (intro circuit dies, an HSDir 5xx's during refresh) are surfaced
+ * via `log` only — they don't reject the original promise or escape.
+ *
+ * The returned `unpublish()` is idempotent and never rejects. The injected
+ * `torClient` is not destroyed; the caller owns it.
+ */
+export async function publishHiddenService(
+  opts: PublishHiddenServiceOptions
+): Promise<HsHost> {
+  const { torClient, port, onConnection, identityKey, log } = opts;
+  if (port <= 0 || port > 0xffff) {
+    throw new Error(`Invalid port ${port}`);
+  }
+  if (typeof onConnection !== 'function') {
+    throw new Error('onConnection must be a function');
+  }
+
+  const keys = identityKey
+    ? loadHiddenServiceKeys(Buffer.from(identityKey))
+    : generateHiddenServiceKeys();
+
+  const constructorOpts = log ? { log } : {};
+  const host = new HiddenServiceHost(keys, constructorOpts);
+  host.setAcceptPort((p) => p === port);
+  host.setOnConnection(onConnection);
+
+  const startOpts: Parameters<HiddenServiceHost['start']>[1] = {};
+  if (opts.numIntroPoints !== undefined) startOpts.numIntroPoints = opts.numIntroPoints;
+  if (opts.descriptorRefreshMs !== undefined) startOpts.descriptorRefreshMs = opts.descriptorRefreshMs;
+  if (opts.perStepTimeoutMs !== undefined) startOpts.perStepTimeoutMs = opts.perStepTimeoutMs;
+
+  await host.start(torClient, startOpts);
+
+  return {
+    onion: host.onionAddress,
+    identityKey: Uint8Array.from(keys.identityPrivateKey),
+    numActiveIntroPoints: () => host.numActiveIntroPoints(),
+    unpublish: () => host.unpublish(),
+  };
+}

--- a/packages/tor/src/hidden-service-host.ts
+++ b/packages/tor/src/hidden-service-host.ts
@@ -197,6 +197,11 @@ export interface Introduce2Decrypted {
  * where checksum = SHA3-256(".onion checksum" || pubkey || version)[:2].
  */
 export function computeOnionAddress(identityPublicKey: Buffer): string {
+  if (identityPublicKey.length !== 32) {
+    throw new Error(
+      `identityPublicKey must be 32 bytes (ed25519 public key), got ${identityPublicKey.length}`
+    );
+  }
   const version = Buffer.from([0x03]);
   const checksum = sha3(
     Buffer.from('.onion checksum', 'ascii'),
@@ -1068,7 +1073,10 @@ export class HiddenServiceHost extends EventEmitter {
    *  `if (this.running)` check. */
   private starting = false;
   private torClient: TorClient<any> | undefined;
-  private refreshInterval: ReturnType<typeof setInterval> | undefined;
+  /** Pending self-scheduled descriptor-refresh timer (see scheduleDescriptorRefresh). */
+  private refreshTimer: ReturnType<typeof setTimeout> | undefined;
+  /** When the timer was armed and for how long, so unpublish() can clear it. */
+  private descriptorRefreshMs = 30 * 60 * 1000;
   /** Target intro-point count, captured from start()'s options for use by
    *  the churn watchdog (which has to know how many to keep alive). */
   private targetIntroPoints = 3;
@@ -1192,12 +1200,13 @@ export class HiddenServiceHost extends EventEmitter {
       }
 
       this.running = true;
-      this.refreshInterval = setInterval(() => {
-        this.uploadDescriptor().catch((err) =>
-          this.log(`descriptor refresh failed: ${err instanceof Error ? err.message : err}`)
-        );
-      }, descriptorRefreshMs);
-      this.refreshInterval.unref?.();
+      // Self-scheduling setTimeout loop instead of setInterval. Per
+      // HS-HOST-API.md §7 the host runs in a service worker; setInterval
+      // gets aggressively throttled on hidden tabs and the queued ticks
+      // can either pile up or never fire after the tab resumes. A
+      // setTimeout that re-arms after each upload lands ensures we
+      // republish ASAP after a long pause, and never queues a backlog.
+      this.scheduleDescriptorRefresh(descriptorRefreshMs);
 
       this.log(`running at ${this.keys.onionAddress}`);
       succeeded = true;
@@ -1296,6 +1305,30 @@ export class HiddenServiceHost extends EventEmitter {
   }
 
   /**
+   * Schedule the next descriptor refresh `delayMs` from now. After the
+   * upload completes (success or failure), re-arm the same timer with the
+   * same delay. Replaces a setInterval so a long pause (service worker
+   * sleeping a hidden tab) doesn't queue a backlog or skew the cadence —
+   * we just publish ASAP after the wakeup and continue.
+   */
+  private scheduleDescriptorRefresh(delayMs: number): void {
+    this.descriptorRefreshMs = delayMs;
+    this.refreshTimer = setTimeout(() => {
+      // If unpublish() ran between scheduling and firing, bail out.
+      if (!this.running) return;
+      this.uploadDescriptor()
+        .catch((err) =>
+          this.log(`descriptor refresh failed: ${err instanceof Error ? err.message : err}`)
+        )
+        .finally(() => {
+          if (this.running) this.scheduleDescriptorRefresh(this.descriptorRefreshMs);
+        });
+    }, delayMs);
+    // Don't hold the event loop open just for this timer.
+    this.refreshTimer.unref?.();
+  }
+
+  /**
    * Pick a fresh relay, establish a new intro point on it, and republish
    * the descriptor. Idempotent against concurrent calls (skips if we've
    * already recovered to `targetIntroPoints`). Best-effort: on failure,
@@ -1360,10 +1393,6 @@ export class HiddenServiceHost extends EventEmitter {
   /**
    * Build, sign, and POST the descriptor to the first ~6 HSDirs in the
    * consensus. Increments `revisionCounter` so refreshes look fresh.
-   */
-  /**
-   * Build, sign, and POST the descriptor to the first ~6 HSDirs in the
-   * consensus. Increments `revisionCounter` so refreshes look fresh.
    *
    * Returns the number of HSDirs that returned a 2xx. The initial publish
    * in {@link start} treats `0` as fatal so the host doesn't claim to be
@@ -1422,18 +1451,32 @@ export class HiddenServiceHost extends EventEmitter {
 
         const responseChunks: Buffer[] = [];
         await new Promise<void>((resolve, reject) => {
-          const timer = setTimeout(() => {
+          // CircuitStream.destroy(err) emits 'error' (circuit.ts) — if we
+          // don't attach a listener Node throws "Unhandled 'error' event"
+          // and tears down the process. Listen + propagate as a rejection
+          // so the surrounding try/catch logs and skips this HSDir cleanly.
+          const cleanup = () => {
+            clearTimeout(timer);
             stream.off('data', onData);
             stream.off('end', onEnd);
+            stream.off('error', onError);
+          };
+          const timer = setTimeout(() => {
+            cleanup();
             reject(new Error('descriptor upload timeout'));
           }, 30_000);
           const onData = (d: Buffer) => responseChunks.push(Buffer.from(d));
           const onEnd = () => {
-            clearTimeout(timer);
+            cleanup();
             resolve();
+          };
+          const onError = (err: Error) => {
+            cleanup();
+            reject(err);
           };
           stream.on('data', onData);
           stream.once('end', onEnd);
+          stream.once('error', onError);
         });
 
         const responseText = Buffer.concat(responseChunks).toString('utf8');
@@ -1579,6 +1622,25 @@ export class HiddenServiceHost extends EventEmitter {
       const portStr = lastColon >= 0 ? addrPort.slice(lastColon + 1) : addrPort;
       const port = Number.parseInt(portStr, 10);
 
+      // Validate port is a real integer in the IANA range BEFORE consulting
+      // the user's acceptPort callback. Otherwise a malformed BEGIN like
+      // "host:abc" would yield port=NaN, which: (a) might bypass naive
+      // user-supplied acceptPort closures (`p === 80` is false for NaN —
+      // safe — but `p > 0` is false too — also safe — but `ports.has(p)`
+      // could behave unexpectedly), and (b) might throw inside a
+      // user-supplied acceptPort that doesn't expect non-finite input.
+      if (!Number.isInteger(port) || port < 1 || port > 65535) {
+        this.log(`refusing BEGIN streamId=${evt.streamId} for invalid port=${portStr}`);
+        circuit
+          .sendRelayMessage({
+            streamId: evt.streamId,
+            relayCommand: RelayCell.END,
+            data: Buffer.from([6]), // REASON_NOTDIRECTORY
+          })
+          .catch(() => undefined);
+        return;
+      }
+
       if (!this.acceptPort(port)) {
         this.log(`refusing BEGIN streamId=${evt.streamId} for port=${port} (filtered)`);
         // Reject with REASON_NOTDIRECTORY (6) — generic "we don't want this".
@@ -1643,12 +1705,16 @@ export class HiddenServiceHost extends EventEmitter {
    * rejects. The injected TorClient is NOT destroyed — the caller owns it.
    */
   async unpublish(): Promise<void> {
-    if (!this.running && this.introPoints.length === 0 && !this.refreshInterval) return;
+    if (!this.running && this.introPoints.length === 0 && !this.refreshTimer) return;
     this.log('stopping hidden service');
+    // Order matters: flip running BEFORE clearing the timer so the
+    // self-scheduling refresh callback (if it fires concurrently with
+    // unpublish) sees `running===false` and bails out rather than
+    // re-arming itself.
     this.running = false;
-    if (this.refreshInterval) {
-      clearInterval(this.refreshInterval);
-      this.refreshInterval = undefined;
+    if (this.refreshTimer) {
+      clearTimeout(this.refreshTimer);
+      this.refreshTimer = undefined;
     }
     for (const intro of this.introPoints) {
       try {

--- a/packages/tor/src/hidden-service-host.ts
+++ b/packages/tor/src/hidden-service-host.ts
@@ -1209,7 +1209,10 @@ export class HiddenServiceHost extends EventEmitter {
         // established (their event listeners would otherwise hold `this`).
         for (const intro of this.introPoints) {
           try {
-            intro.circuit?.destroy();
+            // preserveChannel: TorClient's channelManager may be sharing this
+            // channel with other circuits (incl. the user's bootstrap circuit).
+            // Destroying the channel here would kill those too.
+            intro.circuit?.destroy({ preserveChannel: true });
           } catch {
             // best-effort
           }
@@ -1448,7 +1451,14 @@ export class HiddenServiceHost extends EventEmitter {
         );
       } finally {
         try {
-          circuit?.destroy();
+          // preserveChannel: chutney's small Guard pool means the HSDir
+          // circuit's channel is very likely shared with our intro circuits
+          // (and with the visitor's bootstrap circuit). Destroying the
+          // channel here would tear those down — and the intro circuit
+          // dying makes the IP relay drop our auth-key registration, so
+          // every subsequent INTRODUCE1 NACKs with status=1. This was
+          // exactly the failure on commit 711df09 in chutney.
+          circuit?.destroy({ preserveChannel: true });
         } catch {
           // best-effort
         }
@@ -1515,7 +1525,10 @@ export class HiddenServiceHost extends EventEmitter {
     } finally {
       if (!handedOff) {
         try {
-          rendCircuit.destroy();
+          // preserveChannel: same reasoning as the HSDir-upload teardown —
+          // the rendezvous circuit's channel may be shared with our intro
+          // circuits via the channelManager.
+          rendCircuit.destroy({ preserveChannel: true });
         } catch {
           // best-effort
         }
@@ -1639,7 +1652,10 @@ export class HiddenServiceHost extends EventEmitter {
     }
     for (const intro of this.introPoints) {
       try {
-        intro.circuit?.destroy();
+        // preserveChannel: TorClient's channelManager owns the channels,
+        // not the host. unpublish() shouldn't tear down the user's
+        // bootstrap circuit or any other circuits sharing the same Guard.
+        intro.circuit?.destroy({ preserveChannel: true });
       } catch {
         // best-effort
       }

--- a/packages/tor/src/hidden-service-host.ts
+++ b/packages/tor/src/hidden-service-host.ts
@@ -45,12 +45,7 @@ import { sha512 } from '@noble/hashes/sha512';
 
 import { BytesReader, bufferFromUint } from './util.ts';
 import { RelayCell } from './relay-cell.ts';
-import {
-  Circuit,
-  CircuitStream,
-  type CircuitCipherPair,
-  type PeerInfo,
-} from './circuit.ts';
+import { Circuit, CircuitStream, type CircuitCipherPair, type PeerInfo } from './circuit.ts';
 import { type LinkSpecifier, LinkSpecifierTypes } from './messaging.ts';
 import { pickRelayWithFlags } from './build-circuit/util.ts';
 import {
@@ -293,9 +288,7 @@ export function deriveBlindedPrivateKey(params: {
   // signatures. RH' = SHA-512("Derive temporary signing key hash input" || RH).
   const RH = expanded.subarray(32, 64);
   const RHPrime = Buffer.from(
-    sha512(
-      Buffer.concat([Buffer.from('Derive temporary signing key hash input', 'ascii'), RH])
-    )
+    sha512(Buffer.concat([Buffer.from('Derive temporary signing key hash input', 'ascii'), RH]))
   ).subarray(0, 32);
   const blindedSigningKey = Buffer.concat([blindedPrivateKey, RHPrime]);
 
@@ -375,9 +368,7 @@ export function deriveTimePeriodKeys(params: {
   });
 
   const descriptorSigningPrivateKey = Buffer.from(ed25519.utils.randomPrivateKey());
-  const descriptorSigningPublicKey = Buffer.from(
-    ed25519.getPublicKey(descriptorSigningPrivateKey)
-  );
+  const descriptorSigningPublicKey = Buffer.from(ed25519.getPublicKey(descriptorSigningPrivateKey));
 
   return {
     periodNum,
@@ -951,10 +942,7 @@ export function completeHsNtorServer(params: {
 
   // KDF for rendezvous circuit cipher pair. Same shape as the client's
   // makeHsRendezvousCipherPairFromKeySeed but with the directions swapped.
-  const K = kdfShake256(
-    Buffer.concat([NTOR_KEY_SEED, m_hsexpand]),
-    HASH_LEN * 2 + S_KEY_LEN * 2
-  );
+  const K = kdfShake256(Buffer.concat([NTOR_KEY_SEED, m_hsexpand]), HASH_LEN * 2 + S_KEY_LEN * 2);
   const reader = new BytesReader(K);
   const fSeed = reader.readBytes(HASH_LEN);
   const bSeed = reader.readBytes(HASH_LEN);
@@ -1200,10 +1188,7 @@ export class HiddenServiceHost extends EventEmitter {
    * Build a 3-hop circuit terminating at `intro`, send ESTABLISH_INTRO using
    * the last hop's ntor KH as MAC_KEY, and arm an INTRODUCE2 listener.
    */
-  private async establishIntroPoint(
-    intro: IntroductionPoint,
-    timeoutMs: number
-  ): Promise<void> {
+  private async establishIntroPoint(intro: IntroductionPoint, timeoutMs: number): Promise<void> {
     if (!this.torClient) {
       throw new Error('Hidden service not bootstrapped (torClient missing)');
     }
@@ -1530,7 +1515,6 @@ export class HiddenServiceHost extends EventEmitter {
     this.torClient = undefined;
     this.emit('stopped');
   }
-
 }
 
 // ============================================================================
@@ -1540,11 +1524,7 @@ export class HiddenServiceHost extends EventEmitter {
 // base32EncodeLowerNoPad — live in `./hs-crypto.ts` and the spec imports
 // them from there directly.)
 
-export {
-  curve25519PubkeyToEd25519,
-  encryptDescriptorLayer,
-  createEd25519Certificate,
-};
+export { curve25519PubkeyToEd25519, encryptDescriptorLayer, createEd25519Certificate };
 
 // ============================================================================
 // publishHiddenService — high-level factory matching HS-HOST-API.md
@@ -1600,9 +1580,7 @@ export interface HsHost {
  * The returned `unpublish()` is idempotent and never rejects. The injected
  * `torClient` is not destroyed; the caller owns it.
  */
-export async function publishHiddenService(
-  opts: PublishHiddenServiceOptions
-): Promise<HsHost> {
+export async function publishHiddenService(opts: PublishHiddenServiceOptions): Promise<HsHost> {
   const { torClient, port, onConnection, identityKey, log } = opts;
   if (port <= 0 || port > 0xffff) {
     throw new Error(`Invalid port ${port}`);
@@ -1622,7 +1600,8 @@ export async function publishHiddenService(
 
   const startOpts: Parameters<HiddenServiceHost['start']>[1] = {};
   if (opts.numIntroPoints !== undefined) startOpts.numIntroPoints = opts.numIntroPoints;
-  if (opts.descriptorRefreshMs !== undefined) startOpts.descriptorRefreshMs = opts.descriptorRefreshMs;
+  if (opts.descriptorRefreshMs !== undefined)
+    startOpts.descriptorRefreshMs = opts.descriptorRefreshMs;
   if (opts.perStepTimeoutMs !== undefined) startOpts.perStepTimeoutMs = opts.perStepTimeoutMs;
 
   await host.start(torClient, startOpts);

--- a/packages/tor/src/hidden-service.ts
+++ b/packages/tor/src/hidden-service.ts
@@ -1,18 +1,24 @@
 import {
   x25519,
   ed25519,
-  sha3_256,
-  shake256,
   makeAes256CtrKey,
   randomBytes,
   aes256CtrXor,
   ed25519VerifySync,
+  // rend-spec-v3 helpers (same impl shared by hidden-service-host.ts):
+  sha3,
+  kdfShake256,
+  u64be,
+  mac,
+  dMac,
+  bytesToBigIntLE,
+  createSha3_256Hash,
 } from 'tor-crypto';
 import { BytesReader, shuffleInPlace } from './util.ts';
 import { type LinkSpecifier, LinkSpecifierTypes, RELAY_PAYLOAD_LEN } from './messaging.ts';
 import { RelayCell } from './relay-cell.ts';
 import { parseEd25519Certificate, CertTypes } from './cert.ts';
-import { Circuit, type CircuitCipherPair, type PeerInfo, type CopyableHash } from './circuit.ts';
+import { Circuit, type CircuitCipherPair, type PeerInfo } from './circuit.ts';
 import { pickRelayWithFlags } from './build-circuit/util.ts';
 import { DirectoryClient, lookupPeerInfo } from './directory-client.ts';
 import {
@@ -568,76 +574,6 @@ export function getFetchSrv(
     return consensus.sharedRandCurrentValue ?? disasterSrv;
   }
   return consensus.sharedRandPreviousValue ?? disasterSrv;
-}
-
-function sha3(...parts: Buffer[]): Buffer {
-  return Buffer.from(sha3_256(Buffer.concat(parts)));
-}
-
-/**
- * Browser-compatible SHA3-256 hash wrapper that provides Node.js-like interface.
- * Uses tor-crypto internally, which works in both Node.js and browsers.
- */
-class Sha3_256Hash implements CopyableHash {
-  private accumulated: Uint8Array[] = [];
-
-  update(data: Buffer | Uint8Array): this {
-    // IMPORTANT: Copy the data to avoid issues if the caller mutates the buffer later.
-    // This is critical for relay cell digest computation where the integrity field
-    // is set after the digest is updated.
-    this.accumulated.push(Uint8Array.from(data));
-    return this;
-  }
-
-  copy(): Sha3_256Hash {
-    const cloned = new Sha3_256Hash();
-    cloned.accumulated = [...this.accumulated];
-    return cloned;
-  }
-
-  digest(): Buffer {
-    const totalLength = this.accumulated.reduce((sum, arr) => sum + arr.length, 0);
-    const combined = new Uint8Array(totalLength);
-    let offset = 0;
-    for (const arr of this.accumulated) {
-      combined.set(arr, offset);
-      offset += arr.length;
-    }
-    return Buffer.from(sha3_256(combined));
-  }
-}
-
-function createSha3_256Hash(): Sha3_256Hash {
-  return new Sha3_256Hash();
-}
-
-function bytesToBigIntLE(bytes: Uint8Array): bigint {
-  let n = 0n;
-  for (let i = bytes.length - 1; i >= 0; i--) {
-    n = (n << 8n) | BigInt(bytes[i] ?? 0);
-  }
-  return n;
-}
-
-function kdfShake256(input: Buffer, length: number): Buffer {
-  return Buffer.from(shake256(input, { dkLen: length }));
-}
-
-function u64be(n: bigint): Buffer {
-  const b = Buffer.alloc(8);
-  b.writeBigUInt64BE(n);
-  return b;
-}
-
-function mac(key: Buffer, message: Buffer): Buffer {
-  const keyLen = u64be(BigInt(key.length));
-  return sha3(keyLen, key, message);
-}
-
-function dMac(macKey: Buffer, salt: Buffer, encrypted: Buffer): Buffer {
-  const macKeyLen = u64be(BigInt(macKey.length));
-  const saltLen = u64be(BigInt(salt.length));
-  return sha3(macKeyLen, macKey, saltLen, salt, encrypted);
 }
 
 export function toBase64UrlNoPad(buf: Buffer): string {

--- a/packages/tor/src/index.ts
+++ b/packages/tor/src/index.ts
@@ -15,6 +15,30 @@ export {
 } from './channel.ts';
 export { shuffleInPlace } from './util.ts';
 export * as hiddenService from './hidden-service.ts';
+export * as hiddenServiceHost from './hidden-service-host.ts';
+export {
+  publishHiddenService,
+  HiddenServiceHost,
+  generateHiddenServiceKeys,
+  loadHiddenServiceKeys,
+  computeOnionAddress,
+  deriveBlindedPrivateKey,
+  signWithBlindedKey,
+  deriveTimePeriodKeys,
+  generateIntroPointKeys,
+  generateDescriptor,
+  buildEstablishIntroPayload,
+  parseIntroduce2,
+  decryptIntroduce2,
+  completeHsNtorServer,
+  type PublishHiddenServiceOptions,
+  type HsHost,
+  type HiddenServiceKeys,
+  type TimePeriodKeys,
+  type IntroductionPoint,
+  type Introduce2Parsed,
+  type Introduce2Decrypted,
+} from './hidden-service-host.ts';
 // Consensus parsing (from build-circuit/directory)
 export {
   parseMicroDescConsensus,


### PR DESCRIPTION
Adds server-side v3 onion service hosting to the `tor` package — the missing
half of the existing `hidden-service.ts` client. Public surface matches
`examples/goblin-chat-tor/HS-HOST-API.md`:

```ts
import { publishHiddenService } from 'tor';

const host = await publishHiddenService({
  torClient,                     // any TorClient: chutney, mainnet, or browser/Snowflake
  port,                          // number | number[]
  onConnection: (stream) => {    // CircuitStream per accepted BEGIN
    stream.on('data', (req) => stream.write(makeResponse(req)));
  },
  identityKey?,                  // 32-byte ed25519 seed → pin the .onion
  acceptPort?,                   // optional override for dynamic accept policies
});
// → { onion, identityKey, numActiveIntroPoints(), unpublish() }
```

The host runs in-process with the Tor stack — `onConnection` hands the
application a `CircuitStream` whose `write()` goes via `Circuit.writeToStream`
through the rendezvous circuit's virtual hop and out via the injected
`torClient`'s channel. No "real" socket between application code and the Tor
stack, so the same module works in Node, in the browser via Snowflake, and
in a service worker.

## Protocol fidelity (vs rend-spec-v3 / c-tor / arti)

Port of [PR #21](https://github.com/kumavis/tor-ts/pull/21) with the protocol
bugs caught and fixed:

- ESTABLISH_INTRO body now includes the `SIG_LEN[2]` field between
  `HANDSHAKE_AUTH` and `SIG`.
- `SIG` signs `"Tor establish-intro cell v1" || body || HANDSHAKE_AUTH` (the
  spec-mandated prefix was missing).
- `HANDSHAKE_AUTH` `MAC_KEY` is the last hop's ntor KH, not random bytes —
  required exposing the trailing `DIGEST_LEN` of the ntor KDF as
  `Circuit.getLastHopNtorKh()` (rend-spec-v3 §3.1.1.2 / tor-spec.txt §5.2.2).
- Descriptor signing-key cert (type `0x08`) is signed by the **blinded** key
  using donna-format expanded EdDSA signing (`signWithBlindedKey`), not by
  treating the blinded scalar as a seed.
- `enc-key-cert` (type `0x0b`) certified key is the ed25519 equivalent of the
  curve25519 enc key per proposal 228 appendix A (Edwards-Montgomery
  birational map), not `sha3` of the curve key.
- Auth-clients always padded to a multiple of 16 entries.
- `desc-auth-ephemeral-key` is a real x25519 pubkey, not random bytes.
- Inner descriptor padded to a multiple of 10000 NUL bytes (rend-spec-v3
  §2.5.1.1).
- INTRODUCE2 MAC verifies the **original** payload prefix bytes (including any
  extensions), not a `N_EXT=0` reconstruction (rend-spec-v3 §3.3.2).
- Every line-level base64 field in the descriptor (`introduction-point`,
  `onion-key ntor`, `enc-key ntor`, `desc-auth-ephemeral-key`, `signature`)
  emits with `=` padding stripped — c-tor's HSDir parser rejects the whole
  descriptor with HTTP 400 otherwise (rend-spec-v3 §1.2). Caught from the
  first chutney CI run.
- BEGIN cells coming back through the rendezvous circuit have their port
  parsed and validated to be a finite integer in 1..65535 before consulting
  the user's `acceptPort` policy, so a malformed `addr:port` can't reach
  user code as `NaN`.

## Concurrency / robustness

- `start()` body fully wrapped in try/finally; on failure rolls back partial
  intro circuits + `timePeriodKeys` + `torClient` so the caller can retry.
- `starting` latch defends against concurrent `start()` calls racing past the
  `if (running)` check.
- `'relay'` listeners on intro and rendezvous circuits are detached on the
  circuit's `'destroyed'` event so closures don't pin `this` across churn.
- Intro / rendezvous / HSDir circuits are destroyed on every error path (not
  just success), and **all** host-side `circuit.destroy()` calls pass
  `preserveChannel: true`. The TorClient's `channelManager` shares channels
  across circuits via a Guard pool — destroying an HSDir or rendezvous
  circuit's channel was killing the intro circuits and causing every
  subsequent INTRODUCE1 to NACK with `status=1`. Caught from the second
  chutney CI run after the base64 fix.
- HSDir-upload response wait listens for the stream's `'error'` event in
  addition to `'data'`/`'end'` — `CircuitStream.destroy(err)` emits `'error'`
  and would otherwise be an unhandled-listener crash.
- **Intro-point churn watchdog**: when an intro circuit dies, the host picks a
  fresh relay (avoiding the recent ~20 used + dead candidates), establishes a
  replacement, and republishes the descriptor. Best-effort — failures degrade
  rather than tear down.
- **Self-scheduling descriptor refresh**: the periodic republish uses a
  `setTimeout` that re-arms after each upload completes (instead of
  `setInterval`). Service workers throttle `setInterval` aggressively on
  hidden tabs, which can either pile up queued ticks or skew the cadence;
  the self-scheduling form republishes ASAP after a long pause and never
  builds a backlog.
- `start()` requires at least one HSDir to accept the descriptor before
  resolving — the `.onion` is never reported reachable if zero accepted.
  Periodic 30-min refreshes stay best-effort.

## Crypto

The shared rend-spec-v3 helpers (sha3 + length-prefixed MAC, dMac, kdfShake256,
SHA3-256 streaming hash, base32-lower-no-pad, modular bigint utilities) live in
`tor-crypto/hs-crypto.ts` and are re-exported from both the Node and browser
entry points. Same isomorphic implementation serves the client + the server.

## Tests

- **Unit** (`packages/tor/src/hidden-service-host.spec.ts`): ~35 tests
  covering key derivation (including blinded-public agreement with the client),
  the donna-format blinded EdDSA signing scheme verifying under
  `ed25519VerifySync`, the curve25519→ed25519 birational map, ESTABLISH_INTRO
  byte format + signature, INTRODUCE1→INTRODUCE2 round-trip via the existing
  `buildIntroduce1Payload`, hs-ntor server↔client cipher-pair agreement (one
  side encrypts → the other decrypts), descriptor structure (including a
  regression test that asserts no `=` padding on line-level base64 fields),
  and the `publishHiddenService` argument-validation surface (single port,
  port array, empty port array, non-function `acceptPort` / `onConnection`).
- **Chutney integration** (`packages/tor/scripts/chutney-hidden-service-host-ci.ts`):
  publishes a v3 service via `publishHiddenService` against a chutney network,
  then connects to it via the existing `connectToHiddenService`, asserting
  HTTP round-trip (BEGIN → CONNECTED → DATA → END through the virtual hop).
  Enabled by default (`TOR_TS_CHUTNEY_TESTS` includes `hidden-service-host`)
  so every PR exercises the full HS protocol stack against real chutney
  relays.

## Browser

Imports `events` (polyfilled by `vite-plugin-node-polyfills`), `Buffer`
(polyfilled), `tor-crypto` (isomorphic). No `node:net` / `node:tls` /
`node:fs` / `node:http`. The browser `TorClient` from `packages/browser`
already wires `buildCircuitToTarget` over `SnowflakeBrowserChannel`, so a
service-worker host is one `makeBrowserTorClient` + `publishHiddenService`
call.

## Top-level README

`Hidden service (server side)` moved from the "Not implemented" list to
"Implemented". `packages/tor` description points at
`publishHiddenService` as the entry point.

## Acceptance criteria (from HS-HOST-API.md)

- [x] §1 `publishHiddenService(...)` with the exact signature.
- [x] §2 No `node:net`/`tls`/`fs`/`http` outside browser shims.
- [x] §3 `identityKey` round-trip preserves the `.onion`.
- [x] §4 Server-side hs-ntor + descriptor pipeline + HSDir POST + INTRODUCE2 +
      RENDEZVOUS1 + virtual-hop attachment.
- [x] §5 `publishHiddenService` resolves only after ≥1 IP up + ≥1 HSDir
      accepted; intro churn replaced; `unpublish()` idempotent + non-rejecting.
- [x] §6 Each INTRODUCE2 → its own rendezvous circuit; multiple BEGINs per
      circuit each surface as a separate `onConnection`.
- [x] §7 Descriptor refresh uses a self-scheduling `setTimeout` so the
      platform can't throttle a `setInterval` into uselessness on hidden
      tabs; refresh catches up after long pauses; intro circuits rebuilt on
      churn (and will rebuild after a channel reconnect once the carrying
      channel signals `'destroyed'`); no retained globals preventing
      service-worker termination.
- [x] §8 `publishHiddenService` only rejects on unrecoverable startup errors;
      `unpublish()` never rejects; `onConnection` errors logged + swallowed.
- [x] §9 Unit tests + chutney integration test landed.
- [x] §10 `numActiveIntroPoints()` exposed; multi-port supported.

## Commits

| | |
|---|---|
| `305857f` | `feat(tor/circuit): expose last-hop ntor KH for HS hosting` |
| `967bd9f` | `feat(tor): hidden-service hosting (publishHiddenService + HiddenServiceHost)` |
| `97f9f47` | `refactor: shared crypto in tor-crypto, leak fixes, race guard` |
| `d302ca7` | `style: prettier` |
| `12ec71d` | `fix: address PR review comments (round 1)` (5 from Copilot) |
| `5e258a5` | `fix: clear lint errors` |
| `f8b1e6c` | `feat: intro-point churn watchdog + multi-port support` |
| `c85195e` | `test: enable hidden-service-host in default chutney CI` |
| `711df09` | `fix: emit base64 without padding in line-level descriptor fields` |
| `4633380` | `fix: preserveChannel on host-side circuit destroys` |
| `(this push)` | `fix: address PR review comments (round 2)` |

🤖 Drafted with [Claude Code](https://claude.com/claude-code)