### PR TITLE
docs(examples/goblin-chat-tor): plan tor-ts-native OCapN netlayer + HS-host API contract

### DIFF
--- a/examples/goblin-chat-tor/HS-HOST-API.md
+++ b/examples/goblin-chat-tor/HS-HOST-API.md
@@ -15,28 +15,27 @@ Single entry point, browser-callable, returning a long-lived host handle:
 
 ```ts
 export type PublishHiddenServiceOptions = {
-  torClient: TorClient;                       // browser or node TorClient
-  port: number;                                // virtual port on the .onion
+  torClient: TorClient; // browser or node TorClient
+  port: number; // virtual port on the .onion
   onConnection: (stream: CircuitStream) => void;
-  identityKey?: Ed25519PrivateKeyBytes;        // 32-byte seed; restore .onion
-  numIntroPoints?: number;                     // default 3
-  descriptorLifetimeMs?: number;               // default per spec
+  identityKey?: Ed25519PrivateKeyBytes; // 32-byte seed; restore .onion
+  numIntroPoints?: number; // default 3
+  descriptorLifetimeMs?: number; // default per spec
   log?: (msg: string) => void;
 };
 
 export type HsHost = {
-  readonly onion: string;                      // 56-char-base32 + ".onion"
+  readonly onion: string; // 56-char-base32 + ".onion"
   readonly identityKey: Ed25519PrivateKeyBytes; // raw seed for persistence
   readonly numActiveIntroPoints: () => number;
   unpublish(): Promise<void>;
 };
 
-export function publishHiddenService(
-  opts: PublishHiddenServiceOptions
-): Promise<HsHost>;
+export function publishHiddenService(opts: PublishHiddenServiceOptions): Promise<HsHost>;
 ```
 
 Notes
+
 - `Ed25519PrivateKeyBytes` is the raw 32-byte seed (compatible with
   `tor-crypto`'s ed25519 keygen). No PEM, no Buffer-only types.
 - `CircuitStream` is the existing `tor/relay-cell.ts` / `tor/circuit.ts`
@@ -86,12 +85,12 @@ in `hidden-service.ts`):
 
 ## 5. Lifecycle
 
-| Stage | Expected behavior |
-|---|---|
+| Stage                               | Expected behavior                                                                                                                                                                 |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `publishHiddenService(...)` returns | `numActiveIntroPoints() ≥ 1`, descriptor uploaded to ≥1 HSDir, `.onion` reachable. May return before all intro points are up; a `whenReady()` promise is acceptable but optional. |
-| Steady state | Intro circuits maintained at the configured count; if one dies, replace it within seconds. Republish descriptor at least once per descriptor lifetime, and on intro-point churn. |
-| `unpublish()` | Tear down all intro circuits, stop republish timer, resolve. After resolution no further `onConnection` calls fire. Idempotent. |
-| `torClient` shutdown | If the underlying client is destroyed, the host transitions to a terminal state and stops calling `onConnection`. No unhandled rejections. |
+| Steady state                        | Intro circuits maintained at the configured count; if one dies, replace it within seconds. Republish descriptor at least once per descriptor lifetime, and on intro-point churn.  |
+| `unpublish()`                       | Tear down all intro circuits, stop republish timer, resolve. After resolution no further `onConnection` calls fire. Idempotent.                                                   |
+| `torClient` shutdown                | If the underlying client is destroyed, the host transitions to a terminal state and stops calling `onConnection`. No unhandled rejections.                                        |
 
 ## 6. Concurrency
 
@@ -175,29 +174,31 @@ The HS-host landed in `packages/tor/src/hidden-service-host.ts` and is
 re-exported from `packages/tor/src/index.ts`. Quick pass against the
 contract above:
 
-| § | Item | Shipped | Notes |
-|---|---|:-:|---|
-| 1 | `publishHiddenService(opts) => Promise<HsHost>` | ✅ | Signature matches, `HsHost` shape matches (`onion`, `identityKey`, `numActiveIntroPoints()`, `unpublish()`). |
-| 1 | `Ed25519PrivateKeyBytes` as raw 32-byte seed | ✅ | Accepts `Buffer \| Uint8Array`, returns `Uint8Array`. |
-| 1 | `CircuitStream` accept-callback yield type | ✅ | `onConnection(stream: CircuitStream)`. |
-| 2 | Browser portability | ✅ | No `node:net/tls/fs/dgram/http/crypto/stream/child_process/os/path`. Only Node-shaped import is `events`, which is shimmed by `vite-plugin-node-polyfills` and is `EventEmitter` in browsers. The file's docstring explicitly calls out service-worker compatibility. |
-| 3 | Identity persistence (round-trip seed → same `.onion`) | ✅ | `identityKey` in/out documented as "32-byte ed25519 seed that pins the .onion address". |
-| 4 | Server-side hs-ntor + descriptor pipeline + INTRODUCE2 + ESTABLISH_INTRO + HSDir upload | ✅ | All five exports present (`completeHsNtorServer`, `generateDescriptor`, `parseIntroduce2`, `decryptIntroduce2`, `buildEstablishIntroPayload`). Chutney CI exercises end-to-end. |
-| 5 | Lifecycle (publish resolves once IP up + descriptor uploaded; `unpublish` idempotent + non-rejecting) | ✅ | Documented: "Resolves once at least one introduction point is established AND the descriptor has been uploaded to at least one HSDir … `unpublish()` is idempotent and never rejects." |
-| 5 | Steady-state intro-circuit refresh + descriptor republish | ✅ | `descriptorRefreshMs` (default 30 min), intro-point churn watchdog (commit `157ee9f`). |
-| 6 | Concurrent rendezvous → independent streams per BEGIN | ✅ | Per-stream `onConnection` callback; multi-port via `port: number \| number[]` is a bonus over the contract. |
-| 7 | Service-worker viability | ⚠️ | Asserted in source comments; not yet demonstrated end-to-end under tab-backgrounding. The goblin-chat-tor example is the first user. |
-| 8 | Errors only via `log` in steady state | ✅ | Documented: "Errors during steady state … are surfaced via `log` only — they don't reject the original promise or escape." |
-| 9 | Unit tests + chutney integration | ✅ | `hidden-service-host.spec.ts` plus `scripts/chutney-hidden-service-host-ci.ts`, enabled in CI as of `a5d07e4`. |
-| 10 | Optional: `host.onIntroPointChurn` observable | ➕ partial | `HiddenServiceHost extends EventEmitter` with `'introduce2-error'`, `'rendezvous'`, `'connection'`, `'stopped'` events. The high-level `HsHost` returned by `publishHiddenService` does not surface the EE; if the example wants it, instantiate `HiddenServiceHost` directly. |
+| §   | Item                                                                                                  |  Shipped   | Notes                                                                                                                                                                                                                                                                          |
+| --- | ----------------------------------------------------------------------------------------------------- | :--------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | `publishHiddenService(opts) => Promise<HsHost>`                                                       |     ✅     | Signature matches, `HsHost` shape matches (`onion`, `identityKey`, `numActiveIntroPoints()`, `unpublish()`).                                                                                                                                                                   |
+| 1   | `Ed25519PrivateKeyBytes` as raw 32-byte seed                                                          |     ✅     | Accepts `Buffer \| Uint8Array`, returns `Uint8Array`.                                                                                                                                                                                                                          |
+| 1   | `CircuitStream` accept-callback yield type                                                            |     ✅     | `onConnection(stream: CircuitStream)`.                                                                                                                                                                                                                                         |
+| 2   | Browser portability                                                                                   |     ✅     | No `node:net/tls/fs/dgram/http/crypto/stream/child_process/os/path`. Only Node-shaped import is `events`, which is shimmed by `vite-plugin-node-polyfills` and is `EventEmitter` in browsers. The file's docstring explicitly calls out service-worker compatibility.          |
+| 3   | Identity persistence (round-trip seed → same `.onion`)                                                |     ✅     | `identityKey` in/out documented as "32-byte ed25519 seed that pins the .onion address".                                                                                                                                                                                        |
+| 4   | Server-side hs-ntor + descriptor pipeline + INTRODUCE2 + ESTABLISH_INTRO + HSDir upload               |     ✅     | All five exports present (`completeHsNtorServer`, `generateDescriptor`, `parseIntroduce2`, `decryptIntroduce2`, `buildEstablishIntroPayload`). Chutney CI exercises end-to-end.                                                                                                |
+| 5   | Lifecycle (publish resolves once IP up + descriptor uploaded; `unpublish` idempotent + non-rejecting) |     ✅     | Documented: "Resolves once at least one introduction point is established AND the descriptor has been uploaded to at least one HSDir … `unpublish()` is idempotent and never rejects."                                                                                         |
+| 5   | Steady-state intro-circuit refresh + descriptor republish                                             |     ✅     | `descriptorRefreshMs` (default 30 min), intro-point churn watchdog (commit `157ee9f`).                                                                                                                                                                                         |
+| 6   | Concurrent rendezvous → independent streams per BEGIN                                                 |     ✅     | Per-stream `onConnection` callback; multi-port via `port: number \| number[]` is a bonus over the contract.                                                                                                                                                                    |
+| 7   | Service-worker viability                                                                              |     ⚠️     | Asserted in source comments; not yet demonstrated end-to-end under tab-backgrounding. The goblin-chat-tor example is the first user.                                                                                                                                           |
+| 8   | Errors only via `log` in steady state                                                                 |     ✅     | Documented: "Errors during steady state … are surfaced via `log` only — they don't reject the original promise or escape."                                                                                                                                                     |
+| 9   | Unit tests + chutney integration                                                                      |     ✅     | `hidden-service-host.spec.ts` plus `scripts/chutney-hidden-service-host-ci.ts`, enabled in CI as of `a5d07e4`.                                                                                                                                                                 |
+| 10  | Optional: `host.onIntroPointChurn` observable                                                         | ➕ partial | `HiddenServiceHost extends EventEmitter` with `'introduce2-error'`, `'rendezvous'`, `'connection'`, `'stopped'` events. The high-level `HsHost` returned by `publishHiddenService` does not surface the EE; if the example wants it, instantiate `HiddenServiceHost` directly. |
 
 **Bonus features beyond the contract** (worth knowing about):
+
 - Multi-port: `port: number \| number[]` accepts BEGIN cells for any listed port.
 - Custom `acceptPort: (port: number) => boolean` for wildcard / dynamic services.
 - `perStepTimeoutMs` for per-handshake timeouts.
 - `numActiveIntroPoints()` accessor on `HsHost`.
 
 **Minor gaps** (non-blocking, tracked in [README.md](./README.md) need ranking):
+
 - `packages/browser/src/index.ts` does not re-export `publishHiddenService`.
   Works via `import { publishHiddenService } from 'tor'` but a browser-package
   re-export would mirror the existing `connectToHiddenService` ergonomics.

--- a/examples/goblin-chat-tor/HS-HOST-API.md
+++ b/examples/goblin-chat-tor/HS-HOST-API.md
@@ -1,0 +1,168 @@
+# HS-host API contract
+
+Concrete requirements that the inflight `claude/tor-hidden-services-sDXWN`
+branch must satisfy for the [goblin-chat-tor](./README.md) example to work in
+the browser.
+
+This is a **review checklist for the HS-host branch author**, not a finished
+design. Items 1–8 below are blocking; 9–10 are strongly preferred.
+
+---
+
+## 1. Public API
+
+Single entry point, browser-callable, returning a long-lived host handle:
+
+```ts
+export type PublishHiddenServiceOptions = {
+  torClient: TorClient;                       // browser or node TorClient
+  port: number;                                // virtual port on the .onion
+  onConnection: (stream: CircuitStream) => void;
+  identityKey?: Ed25519PrivateKeyBytes;        // 32-byte seed; restore .onion
+  numIntroPoints?: number;                     // default 3
+  descriptorLifetimeMs?: number;               // default per spec
+  log?: (msg: string) => void;
+};
+
+export type HsHost = {
+  readonly onion: string;                      // 56-char-base32 + ".onion"
+  readonly identityKey: Ed25519PrivateKeyBytes; // raw seed for persistence
+  readonly numActiveIntroPoints: () => number;
+  unpublish(): Promise<void>;
+};
+
+export function publishHiddenService(
+  opts: PublishHiddenServiceOptions
+): Promise<HsHost>;
+```
+
+Notes
+- `Ed25519PrivateKeyBytes` is the raw 32-byte seed (compatible with
+  `tor-crypto`'s ed25519 keygen). No PEM, no Buffer-only types.
+- `CircuitStream` is the existing `tor/relay-cell.ts` / `tor/circuit.ts`
+  stream type used by `connectToHiddenService` — same readable/writable
+  surface so the netlayer treats inbound and outbound symmetrically.
+
+## 2. Browser portability constraints
+
+- No `node:net`, `node:dgram`, `node:fs`, `node:tls`, `node:http` outside the
+  `packages/browser/src/shims/` aliases already used by `tamanegi-browser`.
+- All circuit-building goes through `torClient` (which already abstracts
+  Node TLS vs Snowflake).
+- All TLS is `@reclaimprotocol/tls` via the browser shim — same as the rest
+  of the stack.
+- All randomness is `tor-crypto` (already isomorphic).
+
+## 3. Identity / persistence
+
+- `identityKey` (input) restores the same `.onion` from a previous run.
+- `identityKey` (output) on the returned host is the **same** seed the caller
+  passed in, or the freshly generated one if none was passed.
+- The example will store this in IndexedDB; the HS-host branch is **not**
+  responsible for storage, only for round-tripping bytes.
+- Generation uses ed25519 keygen from `tor-crypto`. Master identity key,
+  blinded keys, and descriptor-signing keys all derived per rend-spec-v3.
+
+## 4. Server-side hs-ntor + descriptor pipeline
+
+The branch must add (currently absent in tor-ts; only the client side exists
+in `hidden-service.ts`):
+
+- **Server-side hs-ntor** handshake (rend-spec-v3 §3.3.2) — derive
+  `KEYS_TARGET` from incoming `INTRODUCE2`, validate `MAC`, produce circuit
+  keys for the rendezvous circuit.
+- **Descriptor build + sign** — outer + inner layers, blinded signing key for
+  the current time period, encrypted with subcredential, padded per spec.
+- **HSDir upload** — symmetric to the existing `selectHsdirsForFetch` /
+  fetch flow in `hidden-service.ts`. POST descriptor to selected HSDirs over
+  directory circuits built via `torClient`.
+- **Intro-point selection + ESTABLISH_INTRO** — pick relays with `Stable` and
+  no `BadExit`, build intro circuits, send `ESTABLISH_INTRO` cells, await
+  `INTRO_ESTABLISHED`.
+- **INTRODUCE2 handler** — on each `INTRODUCE2` from an active intro circuit:
+  parse, verify, do server-side hs-ntor, build the rendezvous circuit to the
+  client-chosen RP, send `RENDEZVOUS1`, then accept `BEGIN` cells on the
+  resulting circuit and yield each as a `CircuitStream` to `onConnection`.
+
+## 5. Lifecycle
+
+| Stage | Expected behavior |
+|---|---|
+| `publishHiddenService(...)` returns | `numActiveIntroPoints() ≥ 1`, descriptor uploaded to ≥1 HSDir, `.onion` reachable. May return before all intro points are up; a `whenReady()` promise is acceptable but optional. |
+| Steady state | Intro circuits maintained at the configured count; if one dies, replace it within seconds. Republish descriptor at least once per descriptor lifetime, and on intro-point churn. |
+| `unpublish()` | Tear down all intro circuits, stop republish timer, resolve. After resolution no further `onConnection` calls fire. Idempotent. |
+| `torClient` shutdown | If the underlying client is destroyed, the host transitions to a terminal state and stops calling `onConnection`. No unhandled rejections. |
+
+## 6. Concurrency
+
+- Multiple `INTRODUCE2`s arriving in parallel must each produce their own
+  rendezvous circuit and their own `CircuitStream`. No serialization, no
+  shared mutable state in the hot path.
+- A single rendezvous circuit may carry multiple `BEGIN` streams (per
+  rend-spec-v3) — each must surface as a separate `onConnection(stream)`
+  call.
+- Backpressure: if `onConnection` throws or the consumer is slow,
+  individual streams may stall, but other streams and the host as a whole
+  must keep functioning.
+
+## 7. Long-lived operation in a service worker
+
+The example will run the host inside a service worker (mirroring
+`tamanegi-browser/src/sw.ts`). The HS-host implementation must:
+
+- Use no global `setInterval` that the platform can throttle into uselessness
+  on hidden tabs without recovery — descriptor republish must catch up after
+  a long pause.
+- Tolerate the underlying `SnowflakeBrowserChannel` reconnecting; intro
+  circuits will need to be rebuilt on top of a fresh channel.
+- Avoid retaining references that prevent the worker from being terminated
+  cleanly when `unpublish()` is called.
+
+## 8. Errors
+
+- `publishHiddenService` rejects only on unrecoverable startup errors
+  (e.g. all intro-point candidates exhausted, all HSDir uploads failed
+  after retry). Transient failures inside the host (one intro circuit
+  dies, one HSDir upload 5xx's) are handled internally and surfaced via
+  `log` only.
+- `unpublish()` never rejects.
+- Errors during `onConnection` callbacks are logged and swallowed — they
+  don't poison the host.
+
+## 9. Testing surface
+
+The branch should land with:
+
+- Unit tests for descriptor build/sign + parse round-trip (against existing
+  parser in `hidden-service.ts`).
+- Unit test for server-side hs-ntor against a known test vector.
+- Integration test on chutney: `publishHiddenService` in one process,
+  `connectToHiddenService` in another, exchange bytes both directions.
+- Bonus: a browser-context test (vitest-browser or playwright) that does
+  the same against chutney via Snowflake.
+
+The example will add an end-to-end live test that chains both sides in the
+same process to prove `connect`/`listen` symmetry.
+
+## 10. Optional but valuable
+
+- `host.onIntroPointChurn(cb)` — observable for UI ("3/3 intro points
+  healthy").
+- `host.republishDescriptor()` — manual trigger for diagnostics.
+- `client-auth` (rend-spec-v3 §G) — out of scope for v1, but the API should
+  not preclude adding it later (e.g. accept an optional `authorizedClients`
+  field that's documented as unimplemented).
+
+---
+
+## Acceptance criteria for unblocking goblin-chat-tor
+
+1. `publishHiddenService` exists with the signature in §1.
+2. The accept callback yields `CircuitStream` instances usable directly with
+   the existing `tor/circuit.ts` stream APIs.
+3. `identityKey` round-trip is exact (same `.onion` on republish).
+4. Two browser tabs, each on the live network, can bootstrap, publish their
+   onion, exchange sturdyrefs out-of-band (paste-in URI), connect, and
+   exchange OCapN frames in both directions for ≥60 seconds without circuit
+   churn breaking the conversation.
+5. `unpublish()` reliably stops the host and releases all circuits.

--- a/examples/goblin-chat-tor/HS-HOST-API.md
+++ b/examples/goblin-chat-tor/HS-HOST-API.md
@@ -166,3 +166,43 @@ same process to prove `connect`/`listen` symmetry.
    exchange OCapN frames in both directions for ≥60 seconds without circuit
    churn breaking the conversation.
 5. `unpublish()` reliably stops the host and releases all circuits.
+
+---
+
+## As-shipped audit (against `main` @ `c5c5519`)
+
+The HS-host landed in `packages/tor/src/hidden-service-host.ts` and is
+re-exported from `packages/tor/src/index.ts`. Quick pass against the
+contract above:
+
+| § | Item | Shipped | Notes |
+|---|---|:-:|---|
+| 1 | `publishHiddenService(opts) => Promise<HsHost>` | ✅ | Signature matches, `HsHost` shape matches (`onion`, `identityKey`, `numActiveIntroPoints()`, `unpublish()`). |
+| 1 | `Ed25519PrivateKeyBytes` as raw 32-byte seed | ✅ | Accepts `Buffer \| Uint8Array`, returns `Uint8Array`. |
+| 1 | `CircuitStream` accept-callback yield type | ✅ | `onConnection(stream: CircuitStream)`. |
+| 2 | Browser portability | ✅ | No `node:net/tls/fs/dgram/http/crypto/stream/child_process/os/path`. Only Node-shaped import is `events`, which is shimmed by `vite-plugin-node-polyfills` and is `EventEmitter` in browsers. The file's docstring explicitly calls out service-worker compatibility. |
+| 3 | Identity persistence (round-trip seed → same `.onion`) | ✅ | `identityKey` in/out documented as "32-byte ed25519 seed that pins the .onion address". |
+| 4 | Server-side hs-ntor + descriptor pipeline + INTRODUCE2 + ESTABLISH_INTRO + HSDir upload | ✅ | All five exports present (`completeHsNtorServer`, `generateDescriptor`, `parseIntroduce2`, `decryptIntroduce2`, `buildEstablishIntroPayload`). Chutney CI exercises end-to-end. |
+| 5 | Lifecycle (publish resolves once IP up + descriptor uploaded; `unpublish` idempotent + non-rejecting) | ✅ | Documented: "Resolves once at least one introduction point is established AND the descriptor has been uploaded to at least one HSDir … `unpublish()` is idempotent and never rejects." |
+| 5 | Steady-state intro-circuit refresh + descriptor republish | ✅ | `descriptorRefreshMs` (default 30 min), intro-point churn watchdog (commit `157ee9f`). |
+| 6 | Concurrent rendezvous → independent streams per BEGIN | ✅ | Per-stream `onConnection` callback; multi-port via `port: number \| number[]` is a bonus over the contract. |
+| 7 | Service-worker viability | ⚠️ | Asserted in source comments; not yet demonstrated end-to-end under tab-backgrounding. The goblin-chat-tor example is the first user. |
+| 8 | Errors only via `log` in steady state | ✅ | Documented: "Errors during steady state … are surfaced via `log` only — they don't reject the original promise or escape." |
+| 9 | Unit tests + chutney integration | ✅ | `hidden-service-host.spec.ts` plus `scripts/chutney-hidden-service-host-ci.ts`, enabled in CI as of `a5d07e4`. |
+| 10 | Optional: `host.onIntroPointChurn` observable | ➕ partial | `HiddenServiceHost extends EventEmitter` with `'introduce2-error'`, `'rendezvous'`, `'connection'`, `'stopped'` events. The high-level `HsHost` returned by `publishHiddenService` does not surface the EE; if the example wants it, instantiate `HiddenServiceHost` directly. |
+
+**Bonus features beyond the contract** (worth knowing about):
+- Multi-port: `port: number \| number[]` accepts BEGIN cells for any listed port.
+- Custom `acceptPort: (port: number) => boolean` for wildcard / dynamic services.
+- `perStepTimeoutMs` for per-handshake timeouts.
+- `numActiveIntroPoints()` accessor on `HsHost`.
+
+**Minor gaps** (non-blocking, tracked in [README.md](./README.md) need ranking):
+- `packages/browser/src/index.ts` does not re-export `publishHiddenService`.
+  Works via `import { publishHiddenService } from 'tor'` but a browser-package
+  re-export would mirror the existing `connectToHiddenService` ergonomics.
+- High-level `HsHost` doesn't expose the underlying `EventEmitter`. Fine for v1.
+
+This contract is **considered satisfied for the purposes of unblocking
+goblin-chat-tor**. Any further work is on the OCapN side or in the example
+itself.

--- a/examples/goblin-chat-tor/README.md
+++ b/examples/goblin-chat-tor/README.md
@@ -68,24 +68,22 @@ examples/goblin-chat-tor/
 
 ## Prerequisites and what each must deliver
 
-### `claude/tor-hidden-services-sDXWN` — HS host (**critical blocker**)
+### tor-ts HS host — **LANDED on `main`** ✅
 
-Detailed contract in [HS-HOST-API.md](./HS-HOST-API.md). Summary:
+Originally tracked as `claude/tor-hidden-services-sDXWN`. Shipped via #39
+(commits `289d54f` … `c5c5519`) as
+[`packages/tor/src/hidden-service-host.ts`](../../packages/tor/src/hidden-service-host.ts).
+The detailed contract in [HS-HOST-API.md](./HS-HOST-API.md) is met — see
+that file's "As-shipped audit" section for the line-by-line diff against
+the contract. Remaining gaps are minor:
 
-- Browser-shaped exports — no `node:net` / `node:dgram` / `node:fs` / `node:tls`
-  outside the existing `packages/browser/src/shims/` aliases. Must ride
-  `TorClient` + `Circuit` + `ChannelManager` like the client side does.
-- `publishHiddenService({ torClient, identityKey?, port, onConnection })`
-  returning `{ onion, identityKey, unpublish() }`.
-- Persistable Ed25519 identity (raw bytes round-trip) so the same `.onion` can
-  be republished across reloads.
-- Server-side hs-ntor (rend-spec-v3 §3.3), INTRODUCE2 parsing, RENDEZVOUS1
-  emission, descriptor upload to selected HSDirs.
-- Long-lived intro-circuit pool (≥3 circuits) with periodic descriptor
-  republish — must work in a service worker.
-- Concurrent rendezvous — multiple inbound peers introduce in parallel, each
-  produces its own `CircuitStream`.
-- Honest `unpublish()` — tears down intro circuits and stops republishing.
+- `packages/browser/src/index.ts` does not re-export `publishHiddenService` /
+  `HsHost` yet — works via `import { publishHiddenService } from 'tor'`, but
+  worth adding a browser-package re-export for symmetry with
+  `connectToHiddenService`.
+- Service-worker viability is *claimed* in source comments and the
+  `EventEmitter` import is bundler-shimmed; not yet *demonstrated* end-to-end
+  under tab-backgrounding. This example will be the first real exercise.
 
 ### `claude/socks-proxy-tor-SRS33` — SOCKS proxy (**out of scope**)
 
@@ -122,19 +120,20 @@ If ocapn isn't on npm with these properties when we're ready to build:
 - Confirm the `tamanegi-browser` service-worker pattern is compatible with the
   HS-host intro-circuit refresh loop.
 
-## Need ranking
+## Need ranking (post-HS-host-landing)
 
-| # | Need | Owner | Blocker? |
+| # | Need | Owner | Status |
 |---|---|---|---|
-| 1 | Browser-shaped HS host with `publish()` accept-callback API | `claude/tor-hidden-services-sDXWN` | **yes** |
-| 2 | Persistable Ed25519 HS identity | `claude/tor-hidden-services-sDXWN` | yes (usable chat) |
-| 3 | Server-side hs-ntor + INTRODUCE2 + descriptor upload | `claude/tor-hidden-services-sDXWN` | yes |
-| 4 | OCapN netlayer registration in browser bundle | ocapn npm | **yes** |
-| 5 | Browser-clean `runChatParticipant`-equivalent | ocapn / goblin-chat npm | yes (or vendor) |
-| 6 | Long-lived intro-circuit refresh inside service worker | tor-ts + HS-host branch | yes (tab backgrounding) |
-| 7 | IndexedDB store for HS identity | tor-ts browser package | yes (stable `.onion`) |
+| 1 | Browser-shaped HS host with `publish()` accept-callback API | tor-ts `main` | **✅ landed** |
+| 2 | Persistable Ed25519 HS identity | tor-ts `main` | **✅ landed** |
+| 3 | Server-side hs-ntor + INTRODUCE2 + descriptor upload | tor-ts `main` | **✅ landed** |
+| 4 | OCapN netlayer registration in browser bundle | ocapn npm | **blocker** |
+| 5 | Browser-clean `runChatParticipant`-equivalent | ocapn / goblin-chat npm | blocker (or vendor) |
+| 6 | Demonstrate long-lived intro-circuit refresh inside service worker | this example | needs E2E test |
+| 7 | IndexedDB store for HS identity | this example (or `packages/browser`) | small task |
 | 8 | `openHsStream(onion, port)` convenience on browser TorClient | tor-ts | nice-to-have |
-| 9 | SOCKS proxy | `claude/socks-proxy-tor-SRS33` | **no** (out of scope) |
+| 9 | Re-export `publishHiddenService` from `packages/browser` | tor-ts | nice-to-have |
+| 10 | SOCKS proxy | `claude/socks-proxy-tor-SRS33` | out of scope |
 
 ## Open questions
 

--- a/examples/goblin-chat-tor/README.md
+++ b/examples/goblin-chat-tor/README.md
@@ -1,0 +1,155 @@
+# goblin-chat-tor (planning)
+
+A static webapp running [OCapN](https://github.com/endojs/endo/tree/master/packages/ocapn)
+goblin-chat over a **custom Tor netlayer backed by tor-ts**, with **bidirectional**
+peer-to-peer messaging directly between browser tabs — no Tor daemon, no SOCKS
+proxy, no Node host.
+
+This directory currently contains design documents only. Implementation is gated
+on the prerequisites listed below.
+
+## Reference
+
+Architecturally equivalent to [endojs/endo#3197](https://github.com/endojs/endo/pull/3197),
+but the daemon-backed netlayer is replaced with a tor-ts-native one that runs in
+the browser.
+
+## Architecture (Arch A only)
+
+Two browser tabs each run the same static webapp. Each tab is **both an OCapN
+client and an OCapN host** — every tab gets its own `.onion` and its own
+sturdyrefs.
+
+```
+  Tab A                                  Tab B
+  ┌────────────────────────┐             ┌────────────────────────┐
+  │  goblin-chat UI        │             │  goblin-chat UI        │
+  │  ─ ocapn client ───────│  Tor HS     │── ocapn client ─       │
+  │  ─ ocapn netlayer ─────│ ────────► ◄ │── ocapn netlayer ──    │
+  │     (custom, tor-ts)   │  rendezvous │     (custom, tor-ts)   │
+  │  ─ TorClient (browser) │             │── TorClient (browser)  │
+  │  ─ Snowflake channel ──│             │── Snowflake channel ─  │
+  └────────────────────────┘             └────────────────────────┘
+```
+
+**Outbound** (`netlayer.connect(loc)`):
+`torClient.connectToHiddenService(loc.designator, port)` → `CircuitStream` →
+OCapN frames.
+
+**Inbound** (`netlayer.listen()`):
+`publishHiddenService({ torClient, port, onConnection })` from the inflight
+HS-host code; `onConnection(stream)` hands each rendezvous stream to OCapN's
+`handlers.onIncoming(stream)`.
+
+The same `TorClient` instance backs both directions. `connectToHiddenService` is
+already browser-callable on tor-ts `main`.
+
+## File layout (planned)
+
+```
+examples/goblin-chat-tor/
+  README.md                  # this file
+  HS-HOST-API.md             # API contract the inflight HS-host branch must satisfy
+  package.json               # tor, browser, @endo/ocapn, @endo/goblin-chat, vite
+  vite.config.ts             # mirrors tamanegi-browser shims/aliases
+  index.html
+  src/
+    main.ts                  # boots TorClient, wires netlayer, runs chat
+    netlayer-tor-ts.ts       # makeTorTsNetLayer({ torClient, hsHost, logger })
+    chat-ui.ts               # sturdyref input, send box, message log
+    sturdyref.ts             # parse/format ocapn:// URIs
+    hs-identity-store.ts     # IndexedDB-backed Ed25519 HS identity persistence
+    sw.ts                    # service worker hosting long-lived intro circuits
+    styles.css
+  test/
+    netlayer.spec.ts         # unit: framing, connect/listen mocks
+    interop.live.spec.ts     # live (chutney + HS host) bidirectional ping
+```
+
+## Prerequisites and what each must deliver
+
+### `claude/tor-hidden-services-sDXWN` — HS host (**critical blocker**)
+
+Detailed contract in [HS-HOST-API.md](./HS-HOST-API.md). Summary:
+
+- Browser-shaped exports — no `node:net` / `node:dgram` / `node:fs` / `node:tls`
+  outside the existing `packages/browser/src/shims/` aliases. Must ride
+  `TorClient` + `Circuit` + `ChannelManager` like the client side does.
+- `publishHiddenService({ torClient, identityKey?, port, onConnection })`
+  returning `{ onion, identityKey, unpublish() }`.
+- Persistable Ed25519 identity (raw bytes round-trip) so the same `.onion` can
+  be republished across reloads.
+- Server-side hs-ntor (rend-spec-v3 §3.3), INTRODUCE2 parsing, RENDEZVOUS1
+  emission, descriptor upload to selected HSDirs.
+- Long-lived intro-circuit pool (≥3 circuits) with periodic descriptor
+  republish — must work in a service worker.
+- Concurrent rendezvous — multiple inbound peers introduce in parallel, each
+  produces its own `CircuitStream`.
+- Honest `unpublish()` — tears down intro circuits and stops republishing.
+
+### `claude/socks-proxy-tor-SRS33` — SOCKS proxy (**out of scope**)
+
+Architecture A does not use SOCKS. The netlayer dials tor-ts circuits directly.
+Tracking removed from this project's blockers.
+
+### OCapN on npm
+
+- Netlayer registration (`client.registerNetlayer(...)` per endo PR #3197) must
+  be reachable from a browser bundle.
+- Sturdyref helpers (`makeSturdyRef`, `enlivenSturdyRef`, `parseSturdyrefUri`)
+  must be browser-callable.
+- `runChatParticipant` (or the underlying chatroom interface) must be free of
+  Node-only imports. The goblin-chat test harness in PR #3197 lives under
+  `test/guile-interop` and may pull in `node:fs` / `node:child_process`; we
+  likely vendor a slim `chat-participant.ts` from the lib path rather than the
+  test path.
+- Stream contract — whatever shape OCapN's netlayer expects (async iterator
+  pair? Node `Duplex`?), tor-ts `CircuitStream` either matches or we adapter
+  it. Pin once a published version is in hand.
+
+If ocapn isn't on npm with these properties when we're ready to build:
+1. `pkg.pr.new` build of the PR branch, or
+2. fork + publish under a scoped name, or
+3. vendor the netlayer interface + sturdyref + chat helpers into the example.
+
+### tor-ts itself (in our court, non-blocking)
+
+- `openHsStream(onion, port)` convenience on the browser `TorClient` — current
+  `connectToHiddenService` returns circuit + intro-points + destroy; we want a
+  plain `CircuitStream`.
+- IndexedDB-backed HS-identity store in `packages/browser`, analogous to
+  `LocalStorageMicrodescStorage`.
+- Confirm the `tamanegi-browser` service-worker pattern is compatible with the
+  HS-host intro-circuit refresh loop.
+
+## Need ranking
+
+| # | Need | Owner | Blocker? |
+|---|---|---|---|
+| 1 | Browser-shaped HS host with `publish()` accept-callback API | `claude/tor-hidden-services-sDXWN` | **yes** |
+| 2 | Persistable Ed25519 HS identity | `claude/tor-hidden-services-sDXWN` | yes (usable chat) |
+| 3 | Server-side hs-ntor + INTRODUCE2 + descriptor upload | `claude/tor-hidden-services-sDXWN` | yes |
+| 4 | OCapN netlayer registration in browser bundle | ocapn npm | **yes** |
+| 5 | Browser-clean `runChatParticipant`-equivalent | ocapn / goblin-chat npm | yes (or vendor) |
+| 6 | Long-lived intro-circuit refresh inside service worker | tor-ts + HS-host branch | yes (tab backgrounding) |
+| 7 | IndexedDB store for HS identity | tor-ts browser package | yes (stable `.onion`) |
+| 8 | `openHsStream(onion, port)` convenience on browser TorClient | tor-ts | nice-to-have |
+| 9 | SOCKS proxy | `claude/socks-proxy-tor-SRS33` | **no** (out of scope) |
+
+## Open questions
+
+- **Service-worker lifetime vs. HS uptime.** A service worker can be evicted
+  while the page is backgrounded; if our intro circuits live there, the
+  `.onion` goes silent. Tab-only hosting means the chat is reachable only while
+  at least one peer keeps the page open. Acceptable for v1, but worth calling
+  out in the UI.
+- **Bootstrap latency.** Snowflake bootstrap + HSDir publish + 3 intro circuits
+  is many seconds before the tab is reachable. UI needs a clear "publishing
+  your onion…" state.
+- **Cross-tab key reuse.** If the user opens two tabs of the app on the same
+  origin, do they share an identity (one `.onion`, two clients) or get
+  separate ones? IndexedDB is shared across same-origin tabs, so default is
+  shared; document this.
+- **NAT / Snowflake reliability.** Hosting an HS over Snowflake is novel — the
+  upstream channel has to stay up far longer than for one-shot fetches in
+  `tamanegi-browser`. May surface bugs in `packages/snowflake`.

--- a/examples/goblin-chat-tor/README.md
+++ b/examples/goblin-chat-tor/README.md
@@ -81,8 +81,8 @@ the contract. Remaining gaps are minor:
   `HsHost` yet — works via `import { publishHiddenService } from 'tor'`, but
   worth adding a browser-package re-export for symmetry with
   `connectToHiddenService`.
-- Service-worker viability is *claimed* in source comments and the
-  `EventEmitter` import is bundler-shimmed; not yet *demonstrated* end-to-end
+- Service-worker viability is _claimed_ in source comments and the
+  `EventEmitter` import is bundler-shimmed; not yet _demonstrated_ end-to-end
   under tab-backgrounding. This example will be the first real exercise.
 
 ### `claude/socks-proxy-tor-SRS33` — SOCKS proxy (**out of scope**)
@@ -106,6 +106,7 @@ Tracking removed from this project's blockers.
   it. Pin once a published version is in hand.
 
 If ocapn isn't on npm with these properties when we're ready to build:
+
 1. `pkg.pr.new` build of the PR branch, or
 2. fork + publish under a scoped name, or
 3. vendor the netlayer interface + sturdyref + chat helpers into the example.
@@ -122,18 +123,18 @@ If ocapn isn't on npm with these properties when we're ready to build:
 
 ## Need ranking (post-HS-host-landing)
 
-| # | Need | Owner | Status |
-|---|---|---|---|
-| 1 | Browser-shaped HS host with `publish()` accept-callback API | tor-ts `main` | **✅ landed** |
-| 2 | Persistable Ed25519 HS identity | tor-ts `main` | **✅ landed** |
-| 3 | Server-side hs-ntor + INTRODUCE2 + descriptor upload | tor-ts `main` | **✅ landed** |
-| 4 | OCapN netlayer registration in browser bundle | ocapn npm | **blocker** |
-| 5 | Browser-clean `runChatParticipant`-equivalent | ocapn / goblin-chat npm | blocker (or vendor) |
-| 6 | Demonstrate long-lived intro-circuit refresh inside service worker | this example | needs E2E test |
-| 7 | IndexedDB store for HS identity | this example (or `packages/browser`) | small task |
-| 8 | `openHsStream(onion, port)` convenience on browser TorClient | tor-ts | nice-to-have |
-| 9 | Re-export `publishHiddenService` from `packages/browser` | tor-ts | nice-to-have |
-| 10 | SOCKS proxy | `claude/socks-proxy-tor-SRS33` | out of scope |
+| #   | Need                                                               | Owner                                | Status              |
+| --- | ------------------------------------------------------------------ | ------------------------------------ | ------------------- |
+| 1   | Browser-shaped HS host with `publish()` accept-callback API        | tor-ts `main`                        | **✅ landed**       |
+| 2   | Persistable Ed25519 HS identity                                    | tor-ts `main`                        | **✅ landed**       |
+| 3   | Server-side hs-ntor + INTRODUCE2 + descriptor upload               | tor-ts `main`                        | **✅ landed**       |
+| 4   | OCapN netlayer registration in browser bundle                      | ocapn npm                            | **blocker**         |
+| 5   | Browser-clean `runChatParticipant`-equivalent                      | ocapn / goblin-chat npm              | blocker (or vendor) |
+| 6   | Demonstrate long-lived intro-circuit refresh inside service worker | this example                         | needs E2E test      |
+| 7   | IndexedDB store for HS identity                                    | this example (or `packages/browser`) | small task          |
+| 8   | `openHsStream(onion, port)` convenience on browser TorClient       | tor-ts                               | nice-to-have        |
+| 9   | Re-export `publishHiddenService` from `packages/browser`           | tor-ts                               | nice-to-have        |
+| 10  | SOCKS proxy                                                        | `claude/socks-proxy-tor-SRS33`       | out of scope        |
 
 ## Open questions
 


### PR DESCRIPTION
Adds design docs for a planned static webapp running OCapN goblin-chat over a
custom Tor netlayer backed by tor-ts (no daemon, no SOCKS, browser-only,
bidirectional peer-to-peer between tabs). Equivalent in spirit to endo PR #3197
but with the netlayer wired through tor-ts circuits + a (still-inflight) HS-host
implementation rather than a real Tor daemon.

- README.md: scope, architecture, file layout, prereq needs, ranking, open
  questions.
- HS-HOST-API.md: concrete API/behavior contract the
  claude/tor-hidden-services-sDXWN branch must satisfy. Acts as a review
  checklist for that branch's author.

No code yet — implementation gated on HS-host landing and OCapN's netlayer hooks
being available in a browser-friendly bundle.

https://claude.ai/code/session_01BNya8eVyJ6gq2FwxKt6Wsm