### PR TITLE
feat(crypto,tor,browser): HS Equi-X proof-of-work + connection fixes + Tamanegi debug logging

### DIFF
--- a/examples/tamanegi-browser/index.html
+++ b/examples/tamanegi-browser/index.html
@@ -200,7 +200,13 @@
               <div class="log-header">
                 <span class="log-title">Connection Log</span>
                 <div class="log-actions">
-                  <button class="log-clear" id="log-download" title="Download full debug log (includes verbose hidden-service diagnostics) for analysis">Download debug log</button>
+                  <button
+                    class="log-clear"
+                    id="log-download"
+                    title="Download full debug log (includes verbose hidden-service diagnostics) for analysis"
+                  >
+                    Download debug log
+                  </button>
                   <button class="log-clear" id="log-clear">Clear</button>
                 </div>
               </div>

--- a/examples/tamanegi-browser/index.html
+++ b/examples/tamanegi-browser/index.html
@@ -199,7 +199,10 @@
             <div class="log-panel" id="log-panel">
               <div class="log-header">
                 <span class="log-title">Connection Log</span>
-                <button class="log-clear" id="log-clear">Clear</button>
+                <div class="log-actions">
+                  <button class="log-clear" id="log-download" title="Download full debug log (includes verbose hidden-service diagnostics) for analysis">Download debug log</button>
+                  <button class="log-clear" id="log-clear">Clear</button>
+                </div>
               </div>
               <div class="log-content" id="log-content"></div>
             </div>

--- a/examples/tamanegi-browser/src/main.ts
+++ b/examples/tamanegi-browser/src/main.ts
@@ -69,6 +69,7 @@ const progressEta = document.getElementById('progress-eta') as HTMLElement;
 // Log panel
 const logContent = document.getElementById('log-content') as HTMLElement;
 const logClear = document.getElementById('log-clear') as HTMLButtonElement;
+const logDownload = document.getElementById('log-download') as HTMLButtonElement;
 
 // Browser panel (iframe persists across mode switches)
 const contentIframe = document.getElementById('content-iframe') as HTMLIFrameElement;
@@ -535,7 +536,10 @@ async function getClient(): Promise<void> {
     connectedResolve = resolve;
   });
 
-  swClient.connect();
+  // Enable verbose hidden-service diagnostics so the downloadable debug log
+  // contains the SRV / time-period / HSDir-ring / per-intro-point detail needed
+  // to analyse a failed .onion connection.
+  swClient.connect({ debug: true });
   return connectedPromise;
 }
 
@@ -1013,6 +1017,44 @@ function clearLog(): void {
   logContent.innerHTML = '';
 }
 
+// Pull the full captured debug log from the service worker and save it as a
+// timestamped .txt file. This is the primary way to get verbose hidden-service
+// diagnostics (which run in the SW, out of reach of the page console) out for
+// analysis.
+async function downloadDebugLog(): Promise<void> {
+  if (!swClient) {
+    log('Service worker not ready; cannot export logs', 'error');
+    return;
+  }
+  logDownload.disabled = true;
+  try {
+    const entries = await swClient.getLogs();
+    const header = [
+      `# TamanegiBrowser debug log`,
+      `# generated: ${new Date().toISOString()}`,
+      `# userAgent: ${navigator.userAgent}`,
+      `# entries: ${entries.length}`,
+      '',
+    ].join('\n');
+    const blob = new Blob([header + entries.join('\n') + '\n'], {
+      type: 'text/plain;charset=utf-8',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `tamanegi-debug-${new Date().toISOString().replace(/[:.]/g, '-')}.txt`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+    log(`Debug log exported (${entries.length} entries)`, 'success');
+  } catch (err) {
+    log(`Failed to export debug log: ${err instanceof Error ? err.message : String(err)}`, 'error');
+  } finally {
+    logDownload.disabled = false;
+  }
+}
+
 // Event listeners
 browseBtn.addEventListener('click', () => {
   const url = urlInput.value.trim();
@@ -1044,6 +1086,7 @@ backBtn.addEventListener('click', navigateBack);
 forwardBtn.addEventListener('click', navigateForward);
 
 logClear.addEventListener('click', clearLog);
+logDownload.addEventListener('click', () => void downloadDebugLog());
 warningDismiss.addEventListener('click', () => {
   warningBanner.hidden = true;
 });

--- a/examples/tamanegi-browser/src/styles.css
+++ b/examples/tamanegi-browser/src/styles.css
@@ -751,6 +751,12 @@ body {
   letter-spacing: 0.5px;
 }
 
+.log-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .log-clear {
   background: transparent;
   border: 1px solid var(--border-subtle);
@@ -767,6 +773,11 @@ body {
 .log-clear:hover {
   color: var(--text-primary);
   border-color: var(--text-muted);
+}
+
+.log-clear:disabled {
+  opacity: 0.5;
+  cursor: default;
 }
 
 .log-content {

--- a/examples/tamanegi-browser/src/sw-messages.ts
+++ b/examples/tamanegi-browser/src/sw-messages.ts
@@ -15,12 +15,14 @@ export const TOR_PROXY_PATH_SEGMENT = 'tor/';
 export type MainToSW =
   | {
       type: 'connect';
-      options?: { relayUrl?: string; skipConsensusCache?: boolean };
+      options?: { relayUrl?: string; skipConsensusCache?: boolean; debug?: boolean };
     }
   | { type: 'fetch'; requestId: string; url: string; timeout?: number }
   | { type: 'refreshConsensus' }
   | { type: 'destroy' }
-  | { type: 'getState' };
+  | { type: 'getState' }
+  /** Request the full captured debug-log buffer (for download / analysis). */
+  | { type: 'getLogs' };
 
 // ---------------------------------------------------------------------------
 // Service worker -> Main page
@@ -47,4 +49,6 @@ export type SWToMain =
     }
   | { type: 'fetchError'; requestId: string; error: string }
   | { type: 'error'; error: string }
-  | { type: 'state'; state: 'idle' | 'connecting' | 'connected' | 'disconnected' };
+  | { type: 'state'; state: 'idle' | 'connecting' | 'connected' | 'disconnected' }
+  /** Full captured debug-log buffer, in response to a `getLogs` request. */
+  | { type: 'logs'; entries: string[] };

--- a/examples/tamanegi-browser/src/sw.ts
+++ b/examples/tamanegi-browser/src/sw.ts
@@ -17,6 +17,28 @@ import { consensusIDB, microdescIDB } from './idb-cache.ts';
 
 let client: BrowserTorClient | null = null;
 
+// ---------------------------------------------------------------------------
+// Debug log capture
+// ---------------------------------------------------------------------------
+//
+// The Tor client runs here in the service worker, whose console is awkward to
+// reach from devtools and impossible to hand off for analysis. So we tee every
+// status/error line into an in-memory ring buffer that the page can pull via
+// the `getLogs` message and offer as a download. Verbose HS diagnostics (SRV /
+// time-period / HSDir-ring / per-intro-point detail) are enabled by passing
+// `debug: true` to the browser client on connect, so they land here too.
+
+const MAX_LOG_ENTRIES = 10_000;
+const logBuffer: string[] = [];
+
+function captureLog(line: string): void {
+  const ts = new Date().toISOString();
+  logBuffer.push(`${ts} ${line}`);
+  if (logBuffer.length > MAX_LOG_ENTRIES) {
+    logBuffer.splice(0, logBuffer.length - MAX_LOG_ENTRIES);
+  }
+}
+
 /**
  * Full proxy path prefix derived from the SW scope so it works under any
  * deployment base path (e.g. "/" locally, "/tor-ts/" on GitHub Pages).
@@ -57,6 +79,28 @@ function mapToHeaders(map: Map<string, string>): Headers {
 // ---------------------------------------------------------------------------
 
 async function broadcast(msg: SWToMain): Promise<void> {
+  // Tee human-readable messages into the debug-log buffer. Progress spam
+  // (consensus/microdesc byte counts) and the log dump itself are skipped.
+  switch (msg.type) {
+    case 'status':
+      captureLog(`[status] ${msg.message}`);
+      break;
+    case 'error':
+      captureLog(`[error] ${msg.error}`);
+      break;
+    case 'fetchError':
+      captureLog(`[fetchError:${msg.requestId}] ${msg.error}`);
+      break;
+    case 'connected':
+      captureLog('[connected]');
+      break;
+    case 'disconnected':
+      captureLog(`[disconnected] ${msg.reason}`);
+      break;
+    default:
+      break;
+  }
+
   const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
   for (const c of clients) {
     c.postMessage(msg);
@@ -132,7 +176,7 @@ self.addEventListener('activate', (e: ExtendableEvent) => {
 // Message handling
 // ---------------------------------------------------------------------------
 
-type ConnectOptions = { relayUrl?: string; skipConsensusCache?: boolean };
+type ConnectOptions = { relayUrl?: string; skipConsensusCache?: boolean; debug?: boolean };
 
 async function handleConnect(options?: ConnectOptions): Promise<void> {
   if (client) {
@@ -140,7 +184,12 @@ async function handleConnect(options?: ConnectOptions): Promise<void> {
     return;
   }
 
+  // Default debug on: this is a diagnostic tool and the verbose HS logs are the
+  // whole point of the log capture. Callers can pass debug: false to quiet it.
+  const debug = options?.debug ?? true;
+
   try {
+    captureLog(`[connect] starting (debug=${debug}, relayUrl=${options?.relayUrl ?? 'default'})`);
     await broadcast({ type: 'state', state: 'connecting' });
 
     const [cachedConsensus, microdescMap] = await Promise.all([
@@ -152,6 +201,7 @@ async function handleConnect(options?: ConnectOptions): Promise<void> {
 
     const { client: c, channel: ch } = await makeBrowserTorClient({
       ...(options?.relayUrl !== undefined ? { relayUrl: options.relayUrl } : {}),
+      debug,
       skipConsensusCache: options?.skipConsensusCache ?? false,
       ...(cachedConsensus !== undefined ? { cachedConsensusText: cachedConsensus } : {}),
       microdescStorage,
@@ -201,8 +251,10 @@ async function handleFetch(requestId: string, url: string, timeout?: number): Pr
     await broadcast({ type: 'fetchError', requestId, error: 'Tor client not connected' });
     return;
   }
+  captureLog(`[fetch:${requestId}] ${url} (timeout=${timeout ?? 'default'})`);
   try {
     const response = await client.fetch(url, timeout !== undefined ? { timeout } : {});
+    captureLog(`[fetch:${requestId}] ${response.status} ${response.statusText}`);
     await broadcast({
       type: 'fetchResult',
       requestId,
@@ -236,6 +288,11 @@ function handleDestroy(): void {
 function handleGetState(): void {
   const state: 'idle' | 'connecting' | 'connected' | 'disconnected' = client ? 'connected' : 'idle';
   void broadcast({ type: 'state', state });
+}
+
+function handleGetLogs(): void {
+  // Snapshot the buffer so the page gets a stable copy.
+  void broadcast({ type: 'logs', entries: [...logBuffer] });
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +372,9 @@ self.addEventListener('message', (e: ExtendableMessageEvent) => {
         break;
       case 'getState':
         void handleGetState();
+        break;
+      case 'getLogs':
+        handleGetLogs();
         break;
       default:
         break;

--- a/examples/tamanegi-browser/src/tor-sw-client.ts
+++ b/examples/tamanegi-browser/src/tor-sw-client.ts
@@ -18,6 +18,7 @@ export class TorServiceWorkerClient {
     string,
     { resolve: (r: FetchResult) => void; reject: (e: Error) => void }
   >();
+  private pendingLogs: Array<(entries: string[]) => void> = [];
   private messageHandler: (e: MessageEvent) => void;
 
   constructor(sw: ServiceWorker | null) {
@@ -81,13 +82,41 @@ export class TorServiceWorkerClient {
       case 'state':
         // Optional: could expose state for UI
         break;
+      case 'logs': {
+        const waiters = this.pendingLogs.splice(0);
+        for (const resolve of waiters) {
+          resolve(msg.entries);
+        }
+        break;
+      }
       default:
         break;
     }
   }
 
-  connect(options?: { relayUrl?: string; skipConsensusCache?: boolean }): void {
+  connect(options?: { relayUrl?: string; skipConsensusCache?: boolean; debug?: boolean }): void {
     this.post({ type: 'connect', ...(options !== undefined ? { options } : {}) });
+  }
+
+  /**
+   * Pull the full captured debug-log buffer from the service worker. Resolves
+   * with an empty array if the SW never responds within the timeout (e.g. no
+   * active controller).
+   */
+  getLogs(timeoutMs = 5000): Promise<string[]> {
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        const idx = this.pendingLogs.indexOf(settle);
+        if (idx !== -1) this.pendingLogs.splice(idx, 1);
+        resolve([]);
+      }, timeoutMs);
+      const settle = (entries: string[]): void => {
+        clearTimeout(timer);
+        resolve(entries);
+      };
+      this.pendingLogs.push(settle);
+      this.post({ type: 'getLogs' });
+    });
   }
 
   fetch(url: string, opts?: { timeout?: number }): Promise<FetchResult> {
@@ -116,6 +145,9 @@ export class TorServiceWorkerClient {
       reject(new Error('Tor client destroyed'));
     }
     this.pendingFetch.clear();
+    for (const resolve of this.pendingLogs.splice(0)) {
+      resolve([]);
+    }
     this.controller = null;
   }
 

--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -138,12 +138,14 @@ export async function makeBrowserTorClient(
 ): Promise<BrowserTorClientResult> {
   const { onStatus, onMicrodescProgress } = options;
 
-  // Turn on verbose HS diagnostics for the whole process when requested. The
-  // core HS code reads this flag at call time via isHsDebugEnabled(), so the
-  // extra `dlog` lines then flow through the `log` callback below (and thus
-  // out through `onStatus`) without any other wiring.
-  if (options.debug) {
-    (globalThis as { __TOR_TS_HS_DEBUG__?: boolean }).__TOR_TS_HS_DEBUG__ = true;
+  // Turn on/off verbose HS diagnostics when the option is given. The core HS
+  // code reads this flag at call time via isHsDebugEnabled(), so the extra
+  // `dlog` lines then flow through the `log` callback below (and thus out
+  // through `onStatus`). Set it symmetrically — an explicit `debug: false` must
+  // turn it back off (the flag is process-global), and omitting `debug` leaves
+  // any existing setting (e.g. the TOR_TS_HS_DEBUG env var) untouched.
+  if (options.debug !== undefined) {
+    (globalThis as { __TOR_TS_HS_DEBUG__?: boolean }).__TOR_TS_HS_DEBUG__ = options.debug;
   }
 
   const log = (msg: string) => {

--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -79,6 +79,17 @@ export type BrowserTorClientOptions = {
   microdescStorage?: MicrodescStorage;
   /** Callback when consensus is updated. Passed to bootstrap. */
   onConsensusUpdate?: (rawContent: string) => void;
+  /**
+   * Enable verbose hidden-service diagnostics (SRV / time-period candidates,
+   * blinded keys, HSDir ring selection, per-intro-point attempts). These are
+   * routed through the same `onStatus` callback as normal status lines, so a
+   * host app can capture them for analysis.
+   *
+   * In Node these logs are gated behind the `TOR_TS_HS_DEBUG` env var; the
+   * browser has no `process.env`, so this option sets the equivalent runtime
+   * flag (`globalThis.__TOR_TS_HS_DEBUG__`).
+   */
+  debug?: boolean;
 };
 
 /**
@@ -127,6 +138,14 @@ export async function makeBrowserTorClient(
 ): Promise<BrowserTorClientResult> {
   const { onStatus, onMicrodescProgress } = options;
 
+  // Turn on verbose HS diagnostics for the whole process when requested. The
+  // core HS code reads this flag at call time via isHsDebugEnabled(), so the
+  // extra `dlog` lines then flow through the `log` callback below (and thus
+  // out through `onStatus`) without any other wiring.
+  if (options.debug) {
+    (globalThis as { __TOR_TS_HS_DEBUG__?: boolean }).__TOR_TS_HS_DEBUG__ = true;
+  }
+
   const log = (msg: string) => {
     console.log(`[tor-client] ${msg}`);
     onStatus?.(msg);
@@ -155,11 +174,23 @@ export async function makeBrowserTorClient(
   channelManager.add(entryPeerInfo.rsaIdDigest, channel);
 
   // Build circuit to a specific target (for hidden services)
-  const buildCircuitToTarget: BuildCircuitFn = async (target) => {
+  const buildCircuitToTarget: BuildCircuitFn = async (target, opts) => {
+    // Exclude the target, our fixed entry (Snowflake bridge), and any relays
+    // the caller asked to avoid. The HS flow passes `{ avoid: [rendezvousPoint] }`
+    // when building the introduction circuit so the rendezvous point can't also
+    // appear as the middle hop — reusing it makes the service silently drop the
+    // introduction, which previously surfaced only as a rendezvous timeout.
+    // We also require Fast + Stable so the middle hop is actually usable for
+    // relaying (the old empty-flags selection could pick an unsuitable relay
+    // and fail the whole HS connection).
+    const avoidDigests = (opts?.avoid ?? []).map((p) => p.rsaIdDigest);
     const candidateRelays = consensus.relays.filter(
-      (r) => !r.rsaIdDigest.equals(target.rsaIdDigest)
+      (r) =>
+        !r.rsaIdDigest.equals(target.rsaIdDigest) &&
+        !r.rsaIdDigest.equals(entryPeerInfo.rsaIdDigest) &&
+        !avoidDigests.some((d) => d.equals(r.rsaIdDigest))
     );
-    const middleNode = pickRelayWithFlags(candidateRelays, [], []);
+    const middleNode = pickRelayWithFlags(candidateRelays, ['Fast', 'Stable'], []);
     const middlePeerInfo = await lookupPeerInfo(dirClient, middleNode);
 
     const circuit = new Circuit({

--- a/packages/crypto/src/browser.ts
+++ b/packages/crypto/src/browser.ts
@@ -18,6 +18,10 @@ export * from './aes.ts';
 // platforms; consumed by the `tor` package's hidden-service client + host).
 export * from './hs-crypto.ts';
 
+// Re-export the hidden-service proof-of-work primitives (HashX + Equi-X +
+// hspow client, proposal 327). Pure computation, identical on both platforms.
+export * from './pow/index.ts';
+
 // Import sha1 for use in computeRsaKeyFingerprint
 import { sha1 } from './hashes.ts';
 

--- a/packages/crypto/src/hashes.ts
+++ b/packages/crypto/src/hashes.ts
@@ -8,6 +8,7 @@ import { sha1 as nobleSha1 } from '@noble/hashes/legacy';
 import { sha256 as nobleSha256, sha512 as nobleSha512 } from '@noble/hashes/sha2';
 import { sha3_256 as nobleSha3_256 } from '@noble/hashes/sha3';
 import { hmac as nobleHmac } from '@noble/hashes/hmac';
+import { blake2b as nobleBlake2b } from '@noble/hashes/blake2b';
 
 // Re-export shake256 directly from @noble/hashes for XOF functionality
 export { shake256 } from '@noble/hashes/sha3';
@@ -46,6 +47,38 @@ export function sha1(...data: (Buffer | Uint8Array)[]): Buffer {
  */
 export function sha256(...data: (Buffer | Uint8Array)[]): Buffer {
   return Buffer.from(nobleSha256(combineInputs(data)));
+}
+
+/**
+ * Compute a BLAKE2b hash.
+ *
+ * Supports the full parameter block (digest length, salt, personalization,
+ * key) so it can produce Argon2/HashX-compatible keyed and salted digests as
+ * well as plain digests. Used by the hidden-service proof-of-work client
+ * (HashX seed expansion + the Equi-X effort hash).
+ *
+ * @param data   - Message to hash.
+ * @param options - Optional BLAKE2b parameters:
+ *   - `dkLen` output length in bytes (default 64, the BLAKE2b maximum)
+ *   - `salt` 16-byte salt (mixed into the parameter block)
+ *   - `personalization` 16-byte personalization string
+ *   - `key` up to 64-byte key for keyed hashing
+ */
+export function blake2b(
+  data: Buffer | Uint8Array,
+  options?: {
+    dkLen?: number;
+    salt?: Buffer | Uint8Array;
+    personalization?: Buffer | Uint8Array;
+    key?: Buffer | Uint8Array;
+  }
+): Buffer {
+  const opts: Record<string, unknown> = {};
+  if (options?.dkLen !== undefined) opts.dkLen = options.dkLen;
+  if (options?.salt !== undefined) opts.salt = options.salt;
+  if (options?.personalization !== undefined) opts.personalization = options.personalization;
+  if (options?.key !== undefined) opts.key = options.key;
+  return Buffer.from(nobleBlake2b(data, opts));
 }
 
 /**

--- a/packages/crypto/src/node.ts
+++ b/packages/crypto/src/node.ts
@@ -21,6 +21,10 @@ export * from './aes.ts';
 // platforms; consumed by the `tor` package's hidden-service client + host).
 export * from './hs-crypto.ts';
 
+// Re-export the hidden-service proof-of-work primitives (HashX + Equi-X +
+// hspow client, proposal 327). Pure computation, identical on both platforms.
+export * from './pow/index.ts';
+
 // Import sha1 for use in computeRsaKeyFingerprint
 import { sha1 } from './hashes.ts';
 

--- a/packages/crypto/src/pow/equix.ts
+++ b/packages/crypto/src/pow/equix.ts
@@ -1,0 +1,362 @@
+/**
+ * Equi-X — a CPU-friendly client puzzle (Equihash-60/3 over HashX).
+ *
+ * Faithful TypeScript port of tevador's reference C solver/verifier
+ * (https://github.com/tevador/equix), the variant used by C Tor's v3
+ * onion-service proof-of-work (proposal 327). A solution is eight 16-bit
+ * indices whose HashX values sum to zero mod 2^60 with the required partial
+ * sums, in canonical tree order.
+ *
+ * The solver is a direct port of Wagner's-algorithm collision search over a
+ * fixed-size hash table heap. Validated against the reference: HashX vectors +
+ * a golden (challenge -> solutions) vector + Tor's hspow verification vectors
+ * (see pow.spec.ts).
+ */
+
+import { hashxExecValue, type HashxProgram } from './hashx.ts';
+
+export const EQUIX_NUM_IDX = 8;
+export const EQUIX_MAX_SOLS = 8;
+
+export const enum EquixResult {
+  OK = 0,
+  CHALLENGE = 1,
+  ORDER = 2,
+  PARTIAL_SUM = 3,
+  FINAL_SUM = 4,
+}
+
+const EQUIX_STAGE1_MASK = (1n << 15n) - 1n;
+const EQUIX_STAGE2_MASK = (1n << 30n) - 1n;
+const EQUIX_FULL_MASK = (1n << 60n) - 1n;
+
+const INDEX_SPACE = 1 << 16; // 65536
+const NUM_COARSE_BUCKETS = 256;
+const NUM_FINE_BUCKETS = 128;
+const COARSE_BUCKET_ITEMS = 336;
+const FINE_BUCKET_ITEMS = 12;
+
+/** Pre-allocated solver scratch space (~2 MB), reusable across solves. */
+class SolverHeap {
+  readonly stage1IdxCounts = new Uint16Array(NUM_COARSE_BUCKETS);
+  readonly stage1Idx = new Uint16Array(NUM_COARSE_BUCKETS * COARSE_BUCKET_ITEMS);
+  readonly stage1Data = new BigUint64Array(NUM_COARSE_BUCKETS * COARSE_BUCKET_ITEMS);
+  readonly stage2IdxCounts = new Uint16Array(NUM_COARSE_BUCKETS);
+  readonly stage2Idx = new Uint32Array(NUM_COARSE_BUCKETS * COARSE_BUCKET_ITEMS);
+  readonly stage2Data = new Float64Array(NUM_COARSE_BUCKETS * COARSE_BUCKET_ITEMS);
+  readonly stage3IdxCounts = new Uint16Array(NUM_COARSE_BUCKETS);
+  readonly stage3Idx = new Uint32Array(NUM_COARSE_BUCKETS * COARSE_BUCKET_ITEMS);
+  readonly stage3Data = new Float64Array(NUM_COARSE_BUCKETS * COARSE_BUCKET_ITEMS);
+  readonly scratchCounts = new Uint8Array(NUM_FINE_BUCKETS);
+  readonly scratch = new Uint16Array(NUM_FINE_BUCKETS * FINE_BUCKET_ITEMS);
+}
+
+let sharedHeap: SolverHeap | null = null;
+
+function invertBucket(idx: number): number {
+  return (NUM_COARSE_BUCKETS - (idx % NUM_COARSE_BUCKETS)) % NUM_COARSE_BUCKETS;
+}
+function invertScratch(idx: number): number {
+  return (NUM_FINE_BUCKETS - (idx % NUM_FINE_BUCKETS)) % NUM_FINE_BUCKETS;
+}
+function makeItem(bucket: number, left: number, right: number): number {
+  return ((left << 17) | (right << 8) | bucket) >>> 0;
+}
+function itemBucket(item: number): number {
+  return item % NUM_COARSE_BUCKETS;
+}
+function itemLeftIdx(item: number): number {
+  return item >>> 17;
+}
+function itemRightIdx(item: number): number {
+  return (item >>> 8) & 511;
+}
+
+// Tree-order comparisons on a solution's 16-bit index array.
+function load32(idx: Uint16Array, o: number): number {
+  return (idx[o]! | (idx[o + 1]! << 16)) >>> 0;
+}
+function load64Idx(idx: Uint16Array, o: number): bigint {
+  return (
+    BigInt(idx[o]!) |
+    (BigInt(idx[o + 1]!) << 16n) |
+    (BigInt(idx[o + 2]!) << 32n) |
+    (BigInt(idx[o + 3]!) << 48n)
+  );
+}
+function treeCmp1(idx: Uint16Array, l: number, r: number): boolean {
+  return idx[l]! <= idx[r]!;
+}
+function treeCmp2(idx: Uint16Array, l: number, r: number): boolean {
+  return load32(idx, l) <= load32(idx, r);
+}
+function treeCmp4(idx: Uint16Array, l: number, r: number): boolean {
+  return load64Idx(idx, l) <= load64Idx(idx, r);
+}
+
+function swap(idx: Uint16Array, a: number, b: number): void {
+  const t = idx[a]!;
+  idx[a] = idx[b]!;
+  idx[b] = t;
+}
+
+function solveStage0(program: HashxProgram, heap: SolverHeap): void {
+  heap.stage1IdxCounts.fill(0);
+  for (let i = 0; i < INDEX_SPACE; ++i) {
+    const value = hashxExecValue(program, BigInt(i));
+    const bucketIdx = Number(value % 256n);
+    const itemIdx = heap.stage1IdxCounts[bucketIdx]!;
+    if (itemIdx >= COARSE_BUCKET_ITEMS) continue;
+    heap.stage1IdxCounts[bucketIdx] = itemIdx + 1;
+    const off = bucketIdx * COARSE_BUCKET_ITEMS + itemIdx;
+    heap.stage1Idx[off] = i;
+    heap.stage1Data[off] = value / 256n;
+  }
+}
+
+function solveStage1(heap: SolverHeap): void {
+  heap.stage2IdxCounts.fill(0);
+  const makePairs1 = (bucketIdx: number, cplBucket: number, itemIdx: number): void => {
+    const carry = bucketIdx !== 0 ? 1n : 0n;
+    const value = heap.stage1Data[bucketIdx * COARSE_BUCKET_ITEMS + itemIdx]! + carry;
+    const fineBuckIdx = Number(value % 128n);
+    const fineCplBucket = invertScratch(fineBuckIdx);
+    const fineCplSize = heap.scratchCounts[fineCplBucket]!;
+    for (let fineIdx = 0; fineIdx < fineCplSize; ++fineIdx) {
+      const cplIndex = heap.scratch[fineCplBucket * FINE_BUCKET_ITEMS + fineIdx]!;
+      const cplValue = heap.stage1Data[cplBucket * COARSE_BUCKET_ITEMS + cplIndex]!;
+      let sum = value + cplValue;
+      sum /= 128n; // 45-50 bits
+      const sumN = Number(sum);
+      const s2BuckId = sumN % NUM_COARSE_BUCKETS;
+      const s2ItemId = heap.stage2IdxCounts[s2BuckId]!;
+      if (s2ItemId >= COARSE_BUCKET_ITEMS) continue;
+      heap.stage2IdxCounts[s2BuckId] = s2ItemId + 1;
+      const off = s2BuckId * COARSE_BUCKET_ITEMS + s2ItemId;
+      heap.stage2Idx[off] = makeItem(bucketIdx, itemIdx, cplIndex);
+      heap.stage2Data[off] = Math.floor(sumN / NUM_COARSE_BUCKETS); // 37 bits
+    }
+  };
+  for (let bucketIdx = 0; bucketIdx < NUM_COARSE_BUCKETS / 2 + 1; ++bucketIdx) {
+    const cplBucket = invertBucket(bucketIdx);
+    heap.scratchCounts.fill(0);
+    const cplBuckSize = heap.stage1IdxCounts[cplBucket]!;
+    for (let itemIdx = 0; itemIdx < cplBuckSize; ++itemIdx) {
+      const value = heap.stage1Data[cplBucket * COARSE_BUCKET_ITEMS + itemIdx]!;
+      const fineBuckIdx = Number(value % 128n);
+      const fineItemIdx = heap.scratchCounts[fineBuckIdx]!;
+      if (fineItemIdx >= FINE_BUCKET_ITEMS) continue;
+      heap.scratchCounts[fineBuckIdx] = fineItemIdx + 1;
+      heap.scratch[fineBuckIdx * FINE_BUCKET_ITEMS + fineItemIdx] = itemIdx;
+      if (cplBucket === bucketIdx) makePairs1(bucketIdx, cplBucket, itemIdx);
+    }
+    if (cplBucket !== bucketIdx) {
+      const buckSize = heap.stage1IdxCounts[bucketIdx]!;
+      for (let itemIdx = 0; itemIdx < buckSize; ++itemIdx)
+        makePairs1(bucketIdx, cplBucket, itemIdx);
+    }
+  }
+}
+
+function solveStage2(heap: SolverHeap): void {
+  heap.stage3IdxCounts.fill(0);
+  const makePairs2 = (bucketIdx: number, cplBucket: number, itemIdx: number): void => {
+    const carry = bucketIdx !== 0 ? 1 : 0;
+    const value = heap.stage2Data[bucketIdx * COARSE_BUCKET_ITEMS + itemIdx]! + carry;
+    const fineBuckIdx = value % NUM_FINE_BUCKETS;
+    const fineCplBucket = invertScratch(fineBuckIdx);
+    const fineCplSize = heap.scratchCounts[fineCplBucket]!;
+    for (let fineIdx = 0; fineIdx < fineCplSize; ++fineIdx) {
+      const cplIndex = heap.scratch[fineCplBucket * FINE_BUCKET_ITEMS + fineIdx]!;
+      const cplValue = heap.stage2Data[cplBucket * COARSE_BUCKET_ITEMS + cplIndex]!;
+      let sum = value + cplValue;
+      sum = Math.floor(sum / NUM_FINE_BUCKETS); // 30 bits
+      const s3BuckId = sum % NUM_COARSE_BUCKETS;
+      const s3ItemId = heap.stage3IdxCounts[s3BuckId]!;
+      if (s3ItemId >= COARSE_BUCKET_ITEMS) continue;
+      heap.stage3IdxCounts[s3BuckId] = s3ItemId + 1;
+      const off = s3BuckId * COARSE_BUCKET_ITEMS + s3ItemId;
+      heap.stage3Idx[off] = makeItem(bucketIdx, itemIdx, cplIndex);
+      heap.stage3Data[off] = Math.floor(sum / NUM_COARSE_BUCKETS); // 22 bits
+    }
+  };
+  for (let bucketIdx = 0; bucketIdx < NUM_COARSE_BUCKETS / 2 + 1; ++bucketIdx) {
+    const cplBucket = invertBucket(bucketIdx);
+    heap.scratchCounts.fill(0);
+    const cplBuckSize = heap.stage2IdxCounts[cplBucket]!;
+    for (let itemIdx = 0; itemIdx < cplBuckSize; ++itemIdx) {
+      const value = heap.stage2Data[cplBucket * COARSE_BUCKET_ITEMS + itemIdx]!;
+      const fineBuckIdx = value % NUM_FINE_BUCKETS;
+      const fineItemIdx = heap.scratchCounts[fineBuckIdx]!;
+      if (fineItemIdx >= FINE_BUCKET_ITEMS) continue;
+      heap.scratchCounts[fineBuckIdx] = fineItemIdx + 1;
+      heap.scratch[fineBuckIdx * FINE_BUCKET_ITEMS + fineItemIdx] = itemIdx;
+      if (cplBucket === bucketIdx) makePairs2(bucketIdx, cplBucket, itemIdx);
+    }
+    if (cplBucket !== bucketIdx) {
+      const buckSize = heap.stage2IdxCounts[bucketIdx]!;
+      for (let itemIdx = 0; itemIdx < buckSize; ++itemIdx)
+        makePairs2(bucketIdx, cplBucket, itemIdx);
+    }
+  }
+}
+
+function buildSolutionStage1(idx: Uint16Array, o: number, heap: SolverHeap, root: number): void {
+  const bucket = itemBucket(root);
+  const bucketInv = invertBucket(bucket);
+  const leftParent = heap.stage1Idx[bucket * COARSE_BUCKET_ITEMS + itemLeftIdx(root)]!;
+  const rightParent = heap.stage1Idx[bucketInv * COARSE_BUCKET_ITEMS + itemRightIdx(root)]!;
+  idx[o] = leftParent;
+  idx[o + 1] = rightParent;
+  if (!treeCmp1(idx, o, o + 1)) swap(idx, o, o + 1);
+}
+
+function buildSolutionStage2(idx: Uint16Array, o: number, heap: SolverHeap, root: number): void {
+  const bucket = itemBucket(root);
+  const bucketInv = invertBucket(bucket);
+  const leftParent = heap.stage2Idx[bucket * COARSE_BUCKET_ITEMS + itemLeftIdx(root)]!;
+  const rightParent = heap.stage2Idx[bucketInv * COARSE_BUCKET_ITEMS + itemRightIdx(root)]!;
+  buildSolutionStage1(idx, o, heap, leftParent);
+  buildSolutionStage1(idx, o + 2, heap, rightParent);
+  if (!treeCmp2(idx, o, o + 2)) {
+    swap(idx, o, o + 2);
+    swap(idx, o + 1, o + 3);
+  }
+}
+
+function buildSolution(heap: SolverHeap, left: number, right: number): Uint16Array {
+  const idx = new Uint16Array(EQUIX_NUM_IDX);
+  buildSolutionStage2(idx, 0, heap, left);
+  buildSolutionStage2(idx, 4, heap, right);
+  if (!treeCmp4(idx, 0, 4)) {
+    swap(idx, 0, 4);
+    swap(idx, 1, 5);
+    swap(idx, 2, 6);
+    swap(idx, 3, 7);
+  }
+  return idx;
+}
+
+function solveStage3(heap: SolverHeap): Uint16Array[] {
+  const out: Uint16Array[] = [];
+  const makePairs3 = (bucketIdx: number, cplBucket: number, itemIdx: number): boolean => {
+    const carry = bucketIdx !== 0 ? 1 : 0;
+    const value = heap.stage3Data[bucketIdx * COARSE_BUCKET_ITEMS + itemIdx]! + carry;
+    const fineBuckIdx = value % NUM_FINE_BUCKETS;
+    const fineCplBucket = invertScratch(fineBuckIdx);
+    const fineCplSize = heap.scratchCounts[fineCplBucket]!;
+    for (let fineIdx = 0; fineIdx < fineCplSize; ++fineIdx) {
+      const cplIndex = heap.scratch[fineCplBucket * FINE_BUCKET_ITEMS + fineIdx]!;
+      const cplValue = heap.stage3Data[cplBucket * COARSE_BUCKET_ITEMS + cplIndex]!;
+      let sum = value + cplValue;
+      sum = Math.floor(sum / NUM_FINE_BUCKETS); // 15 bits
+      if ((BigInt(sum) & EQUIX_STAGE1_MASK) === 0n) {
+        const itemLeft = heap.stage3Idx[bucketIdx * COARSE_BUCKET_ITEMS + itemIdx]!;
+        const itemRight = heap.stage3Idx[cplBucket * COARSE_BUCKET_ITEMS + cplIndex]!;
+        out.push(buildSolution(heap, itemLeft, itemRight));
+        if (out.length >= EQUIX_MAX_SOLS) return true;
+      }
+    }
+    return false;
+  };
+  for (let bucketIdx = 0; bucketIdx < NUM_COARSE_BUCKETS / 2 + 1; ++bucketIdx) {
+    const cplBucket = (-bucketIdx & (NUM_COARSE_BUCKETS - 1)) >>> 0;
+    heap.scratchCounts.fill(0);
+    const cplBuckSize = heap.stage3IdxCounts[cplBucket]!;
+    for (let itemIdx = 0; itemIdx < cplBuckSize; ++itemIdx) {
+      const value = heap.stage3Data[cplBucket * COARSE_BUCKET_ITEMS + itemIdx]!;
+      const fineBuckIdx = value % NUM_FINE_BUCKETS;
+      const fineItemIdx = heap.scratchCounts[fineBuckIdx]!;
+      if (fineItemIdx >= FINE_BUCKET_ITEMS) continue;
+      heap.scratchCounts[fineBuckIdx] = fineItemIdx + 1;
+      heap.scratch[fineBuckIdx * FINE_BUCKET_ITEMS + fineItemIdx] = itemIdx;
+      if (cplBucket === bucketIdx) {
+        if (makePairs3(bucketIdx, cplBucket, itemIdx)) return out;
+      }
+    }
+    if (cplBucket !== bucketIdx) {
+      const buckSize = heap.stage3IdxCounts[bucketIdx]!;
+      for (let itemIdx = 0; itemIdx < buckSize; ++itemIdx) {
+        if (makePairs3(bucketIdx, cplBucket, itemIdx)) return out;
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Find Equi-X solutions for a challenge whose HashX program is `program`.
+ * Returns 0..EQUIX_MAX_SOLS solutions, each an 8-element Uint16Array of indices
+ * in canonical order (matching the reference solver's output and ordering).
+ */
+export function equixSolve(program: HashxProgram): Uint16Array[] {
+  if (!sharedHeap) sharedHeap = new SolverHeap();
+  const heap = sharedHeap;
+  solveStage0(program, heap);
+  solveStage1(heap);
+  solveStage2(heap);
+  return solveStage3(heap);
+}
+
+function verifyOrder(idx: Uint16Array): boolean {
+  return (
+    treeCmp4(idx, 0, 4) &&
+    treeCmp2(idx, 0, 2) &&
+    treeCmp2(idx, 4, 6) &&
+    treeCmp1(idx, 0, 1) &&
+    treeCmp1(idx, 2, 3) &&
+    treeCmp1(idx, 4, 5) &&
+    treeCmp1(idx, 6, 7)
+  );
+}
+
+function sumPair(program: HashxProgram, left: number, right: number): bigint {
+  return (
+    (hashxExecValue(program, BigInt(left)) + hashxExecValue(program, BigInt(right))) &
+    ((1n << 64n) - 1n)
+  );
+}
+
+/**
+ * Verify an Equi-X solution against its HashX program. Mirrors
+ * `equix_verify`: checks canonical ordering, the stage partial sums, and the
+ * final zero sum mod 2^60.
+ */
+export function equixVerify(program: HashxProgram, idx: Uint16Array): EquixResult {
+  if (!verifyOrder(idx)) return EquixResult.ORDER;
+  const MASK = (1n << 64n) - 1n;
+  const pair0 = sumPair(program, idx[0]!, idx[1]!);
+  if (pair0 & EQUIX_STAGE1_MASK) return EquixResult.PARTIAL_SUM;
+  const pair1 = sumPair(program, idx[2]!, idx[3]!);
+  if (pair1 & EQUIX_STAGE1_MASK) return EquixResult.PARTIAL_SUM;
+  const pair4 = (pair0 + pair1) & MASK;
+  if (pair4 & EQUIX_STAGE2_MASK) return EquixResult.PARTIAL_SUM;
+  const pair2 = sumPair(program, idx[4]!, idx[5]!);
+  if (pair2 & EQUIX_STAGE1_MASK) return EquixResult.PARTIAL_SUM;
+  const pair3 = sumPair(program, idx[6]!, idx[7]!);
+  if (pair3 & EQUIX_STAGE1_MASK) return EquixResult.PARTIAL_SUM;
+  const pair5 = (pair2 + pair3) & MASK;
+  if (pair5 & EQUIX_STAGE2_MASK) return EquixResult.PARTIAL_SUM;
+  const pair6 = (pair4 + pair5) & MASK;
+  if (pair6 & EQUIX_FULL_MASK) return EquixResult.FINAL_SUM;
+  return EquixResult.OK;
+}
+
+/** Serialize an Equi-X solution to 16 bytes: 8 little-endian uint16 indices. */
+export function packEquixSolution(idx: Uint16Array): Buffer {
+  const out = Buffer.alloc(16);
+  for (let i = 0; i < EQUIX_NUM_IDX; ++i) {
+    out[i * 2] = idx[i]! & 0xff;
+    out[i * 2 + 1] = (idx[i]! >> 8) & 0xff;
+  }
+  return out;
+}
+
+/** Parse 16 solution bytes (8 little-endian uint16 indices) into an index array. */
+export function unpackEquixSolution(bytes: Buffer | Uint8Array): Uint16Array {
+  const idx = new Uint16Array(EQUIX_NUM_IDX);
+  for (let i = 0; i < EQUIX_NUM_IDX; ++i) {
+    idx[i] = (bytes[i * 2]! | (bytes[i * 2 + 1]! << 8)) & 0xffff;
+  }
+  return idx;
+}

--- a/packages/crypto/src/pow/hashx.ts
+++ b/packages/crypto/src/pow/hashx.ts
@@ -1,0 +1,811 @@
+/**
+ * HashX — a keyed, pseudo-randomly generated hash function.
+ *
+ * Faithful TypeScript port of tevador's reference C implementation
+ * (https://github.com/tevador/hashx), the same code vendored by C Tor as
+ * `src/ext/equix/hashx` and used by the v3 onion-service proof-of-work scheme
+ * (proposal 327 / hspow-spec). Each seed deterministically generates a unique
+ * straight-line integer program; hashing an input runs that program over eight
+ * 64-bit registers.
+ *
+ * This is the interpreted variant (the C "compiled" JIT path is irrelevant in
+ * JS). Validated byte-for-byte against the reference `hashx-tests` vectors —
+ * see pow.spec.ts.
+ *
+ * All 64-bit arithmetic uses BigInt masked to 64 bits. This is not fast, but
+ * it is exact; performance is bounded by the caller's effort budget.
+ */
+
+import { blake2b } from '../hashes.ts';
+
+const MASK64 = (1n << 64n) - 1n;
+const u64 = (x: bigint): bigint => x & MASK64;
+
+function rotl64(x: bigint, b: bigint): bigint {
+  return u64((x << b) | (x >> (64n - b)));
+}
+
+/** SipHash round on a 4-element BigInt register array (mutates in place). */
+function sipround(v: bigint[]): void {
+  let [v0, v1, v2, v3] = v;
+  v0 = u64(v0! + v1!);
+  v2 = u64(v2! + v3!);
+  v1 = rotl64(v1!, 13n);
+  v3 = rotl64(v3!, 16n);
+  v1 ^= v0;
+  v3 ^= v2;
+  v0 = rotl64(v0, 32n);
+  v2 = u64(v2 + v1);
+  v0 = u64(v0 + v3);
+  v1 = rotl64(v1, 17n);
+  v3 = rotl64(v3, 21n);
+  v1 ^= v2;
+  v3 ^= v0;
+  v2 = rotl64(v2, 32n);
+  v[0] = v0;
+  v[1] = v1;
+  v[2] = v2;
+  v[3] = v3;
+}
+
+export interface SiphashState {
+  v0: bigint;
+  v1: bigint;
+  v2: bigint;
+  v3: bigint;
+}
+
+/** hashx_siphash13_ctr */
+function siphash13Ctr(input: bigint, keys: SiphashState): bigint {
+  const v = [keys.v0, keys.v1, keys.v2, keys.v3 ^ input];
+  sipround(v);
+  v[0] = v[0]! ^ input;
+  v[2] = v[2]! ^ 0xffn;
+  sipround(v);
+  sipround(v);
+  sipround(v);
+  return u64(v[0]! ^ v[1]! ^ (v[2]! ^ v[3]!));
+}
+
+/** hashx_siphash24_ctr_state512 — produces the 8 initial registers. */
+function siphash24CtrState512(keys: SiphashState, input: bigint): bigint[] {
+  const v = [keys.v0, keys.v1 ^ 0xeen, keys.v2, keys.v3 ^ input];
+  sipround(v);
+  sipround(v);
+  v[0] = v[0]! ^ input;
+  v[2] = v[2]! ^ 0xeen;
+  sipround(v);
+  sipround(v);
+  sipround(v);
+  sipround(v);
+  const out = [v[0]!, v[1]!, v[2]!, v[3]!, 0n, 0n, 0n, 0n];
+  v[1] = v[1]! ^ 0xddn;
+  sipround(v);
+  sipround(v);
+  sipround(v);
+  sipround(v);
+  out[4] = v[0]!;
+  out[5] = v[1]!;
+  out[6] = v[2]!;
+  out[7] = v[3]!;
+  return out;
+}
+
+/** siphash_rng — pseudo-random stream used by the program generator. */
+class SiphashRng {
+  private keys: SiphashState;
+  private counter = 0n;
+  private buffer8 = 0n;
+  private buffer32 = 0n;
+  private count8 = 0;
+  private count32 = 0;
+
+  constructor(state: SiphashState) {
+    this.keys = state;
+  }
+
+  u8(): number {
+    if (this.count8 === 0) {
+      this.buffer8 = siphash13Ctr(this.counter, this.keys);
+      this.counter = u64(this.counter + 1n);
+      this.count8 = 8;
+    }
+    this.count8--;
+    return Number((this.buffer8 >> BigInt(this.count8 * 8)) & 0xffn);
+  }
+
+  u32(): number {
+    if (this.count32 === 0) {
+      this.buffer32 = siphash13Ctr(this.counter, this.keys);
+      this.counter = u64(this.counter + 1n);
+      this.count32 = 2;
+    }
+    this.count32--;
+    return Number((this.buffer32 >> BigInt(this.count32 * 32)) & 0xffffffffn) >>> 0;
+  }
+}
+
+// ============================================================================
+// Instruction set (mirrors instruction.h)
+// ============================================================================
+
+const enum Op {
+  UMULH_R = 0,
+  SMULH_R = 1,
+  MUL_R = 2,
+  SUB_R = 3,
+  XOR_R = 4,
+  ADD_RS = 5,
+  ROR_C = 6,
+  ADD_C = 7,
+  XOR_C = 8,
+  TARGET = 9,
+  BRANCH = 10,
+}
+
+interface Instruction {
+  opcode: Op;
+  src: number;
+  dst: number;
+  imm32: number;
+  opPar: number;
+}
+
+// Execution ports (Ivy Bridge P0/P1/P5 model).
+const PORT_NONE = 0;
+const PORT_P0 = 1;
+const PORT_P1 = 2;
+const PORT_P5 = 4;
+const PORT_P01 = PORT_P0 | PORT_P1;
+const PORT_P05 = PORT_P0 | PORT_P5;
+const PORT_P015 = PORT_P0 | PORT_P1 | PORT_P5;
+
+interface InstrTemplate {
+  type: Op;
+  latency: number;
+  uop1: number;
+  uop2: number;
+  immediateMask: number;
+  group: Op;
+  immCanBeZero: boolean;
+  distinctDst: boolean;
+  opParSrc: boolean;
+  hasSrc: boolean;
+  hasDst: boolean;
+}
+
+const BRANCH_MASK = 0x80000000;
+
+const tpl_umulh_r: InstrTemplate = {
+  type: Op.UMULH_R,
+  latency: 4,
+  uop1: PORT_P1,
+  uop2: PORT_P5,
+  immediateMask: 0,
+  group: Op.UMULH_R,
+  immCanBeZero: false,
+  distinctDst: false,
+  opParSrc: false,
+  hasSrc: true,
+  hasDst: true,
+};
+const tpl_smulh_r: InstrTemplate = {
+  type: Op.SMULH_R,
+  latency: 4,
+  uop1: PORT_P1,
+  uop2: PORT_P5,
+  immediateMask: 0,
+  group: Op.SMULH_R,
+  immCanBeZero: false,
+  distinctDst: false,
+  opParSrc: false,
+  hasSrc: true,
+  hasDst: true,
+};
+const tpl_mul_r: InstrTemplate = {
+  type: Op.MUL_R,
+  latency: 3,
+  uop1: PORT_P1,
+  uop2: PORT_NONE,
+  immediateMask: 0,
+  group: Op.MUL_R,
+  immCanBeZero: false,
+  distinctDst: true,
+  opParSrc: true,
+  hasSrc: true,
+  hasDst: true,
+};
+const tpl_sub_r: InstrTemplate = {
+  type: Op.SUB_R,
+  latency: 1,
+  uop1: PORT_P015,
+  uop2: PORT_NONE,
+  immediateMask: 0,
+  group: Op.ADD_RS,
+  immCanBeZero: false,
+  distinctDst: true,
+  opParSrc: true,
+  hasSrc: true,
+  hasDst: true,
+};
+const tpl_xor_r: InstrTemplate = {
+  type: Op.XOR_R,
+  latency: 1,
+  uop1: PORT_P015,
+  uop2: PORT_NONE,
+  immediateMask: 0,
+  group: Op.XOR_R,
+  immCanBeZero: false,
+  distinctDst: true,
+  opParSrc: true,
+  hasSrc: true,
+  hasDst: true,
+};
+const tpl_add_rs: InstrTemplate = {
+  type: Op.ADD_RS,
+  latency: 1,
+  uop1: PORT_P01,
+  uop2: PORT_NONE,
+  immediateMask: 3,
+  group: Op.ADD_RS,
+  immCanBeZero: true,
+  distinctDst: true,
+  opParSrc: true,
+  hasSrc: true,
+  hasDst: true,
+};
+const tpl_ror_c: InstrTemplate = {
+  type: Op.ROR_C,
+  latency: 1,
+  uop1: PORT_P05,
+  uop2: PORT_NONE,
+  immediateMask: 63,
+  group: Op.ROR_C,
+  immCanBeZero: false,
+  distinctDst: true,
+  opParSrc: false,
+  hasSrc: false,
+  hasDst: true,
+};
+const tpl_add_c: InstrTemplate = {
+  type: Op.ADD_C,
+  latency: 1,
+  uop1: PORT_P015,
+  uop2: PORT_NONE,
+  immediateMask: 0xffffffff,
+  group: Op.ADD_C,
+  immCanBeZero: false,
+  distinctDst: true,
+  opParSrc: false,
+  hasSrc: false,
+  hasDst: true,
+};
+const tpl_xor_c: InstrTemplate = {
+  type: Op.XOR_C,
+  latency: 1,
+  uop1: PORT_P015,
+  uop2: PORT_NONE,
+  immediateMask: 0xffffffff,
+  group: Op.XOR_C,
+  immCanBeZero: false,
+  distinctDst: true,
+  opParSrc: false,
+  hasSrc: false,
+  hasDst: true,
+};
+const tpl_target: InstrTemplate = {
+  type: Op.TARGET,
+  latency: 1,
+  uop1: PORT_P015,
+  uop2: PORT_P015,
+  immediateMask: 0,
+  group: Op.TARGET,
+  immCanBeZero: false,
+  distinctDst: true,
+  opParSrc: false,
+  hasSrc: false,
+  hasDst: false,
+};
+const tpl_branch: InstrTemplate = {
+  type: Op.BRANCH,
+  latency: 1,
+  uop1: PORT_P015,
+  uop2: PORT_P015,
+  immediateMask: BRANCH_MASK,
+  group: Op.BRANCH,
+  immCanBeZero: false,
+  distinctDst: true,
+  opParSrc: false,
+  hasSrc: false,
+  hasDst: false,
+};
+
+const instr_lookup = [
+  tpl_ror_c,
+  tpl_xor_c,
+  tpl_add_c,
+  tpl_add_c,
+  tpl_sub_r,
+  tpl_xor_r,
+  tpl_xor_c,
+  tpl_add_rs,
+];
+const wide_mul_lookup = [tpl_smulh_r, tpl_umulh_r];
+
+interface ProgramItem {
+  templates: InstrTemplate[];
+  mask0: number;
+  mask1: number;
+  duplicates: boolean;
+}
+
+const item_mul: ProgramItem = { templates: [tpl_mul_r], mask0: 0, mask1: 0, duplicates: true };
+const item_target: ProgramItem = { templates: [tpl_target], mask0: 0, mask1: 0, duplicates: true };
+const item_branch: ProgramItem = { templates: [tpl_branch], mask0: 0, mask1: 0, duplicates: true };
+const item_wide_mul: ProgramItem = {
+  templates: wide_mul_lookup,
+  mask0: 1,
+  mask1: 1,
+  duplicates: true,
+};
+const item_any: ProgramItem = { templates: instr_lookup, mask0: 7, mask1: 3, duplicates: false };
+
+// prettier-ignore
+const program_layout: ProgramItem[] = [
+  item_mul, item_target, item_any, item_mul, item_any, item_any,
+  item_mul, item_any, item_any, item_mul, item_any, item_any,
+  item_wide_mul, item_any, item_any, item_mul, item_any, item_any,
+  item_mul, item_branch, item_any, item_mul, item_any, item_any,
+  item_wide_mul, item_any, item_any, item_mul, item_any, item_any,
+  item_mul, item_any, item_any, item_mul, item_any, item_any,
+];
+
+const TARGET_CYCLE = 192;
+const REQUIREMENT_SIZE = 512;
+const REQUIREMENT_MUL_COUNT = 192;
+const REQUIREMENT_LATENCY = 195;
+const REGISTER_NEEDS_DISPLACEMENT = 5;
+const PORT_MAP_SIZE = TARGET_CYCLE + 4;
+const NUM_PORTS = 3;
+const MAX_RETRIES = 1;
+const LOG2_BRANCH_PROB = 4;
+const HASHX_PROGRAM_MAX_SIZE = 512;
+
+function isMul(type: Op): boolean {
+  return type <= Op.MUL_R;
+}
+
+interface RegisterInfo {
+  latency: number;
+  lastOp: number; // Op or -1
+  lastOpPar: number; // uint32 or 0xffffffff sentinel
+}
+
+interface GeneratorCtx {
+  cycle: number;
+  subCycle: number;
+  mulCount: number;
+  chainMul: boolean;
+  latency: number;
+  gen: SiphashRng;
+  registers: RegisterInfo[];
+  ports: Int32Array[]; // [PORT_MAP_SIZE][NUM_PORTS]
+}
+
+function selectTemplate(ctx: GeneratorCtx, lastInstr: number, attempt: number): InstrTemplate {
+  const item = program_layout[ctx.subCycle % 36]!;
+  let tpl: InstrTemplate;
+  do {
+    const index = item.mask0 ? ctx.gen.u8() & (attempt > 0 ? item.mask1 : item.mask0) : 0;
+    tpl = item.templates[index]!;
+  } while (!item.duplicates && tpl.group === lastInstr);
+  return tpl;
+}
+
+function branchMask(gen: SiphashRng): number {
+  let mask = 0;
+  let popcnt = 0;
+  while (popcnt < LOG2_BRANCH_PROB) {
+    const bit = gen.u8() % 32;
+    const bitmask = (1 << bit) >>> 0;
+    if (!(mask & bitmask)) {
+      mask = (mask | bitmask) >>> 0;
+      popcnt++;
+    }
+  }
+  return mask >>> 0;
+}
+
+function instrFromTemplate(tpl: InstrTemplate, gen: SiphashRng, instr: Instruction): void {
+  instr.opcode = tpl.type;
+  if (tpl.immediateMask) {
+    if (tpl.immediateMask === BRANCH_MASK) {
+      instr.imm32 = branchMask(gen);
+    } else {
+      do {
+        instr.imm32 = (gen.u32() & tpl.immediateMask) >>> 0;
+      } while (instr.imm32 === 0 && !tpl.immCanBeZero);
+    }
+  }
+  if (!tpl.opParSrc) {
+    if (tpl.distinctDst) {
+      instr.opPar = 0xffffffff;
+    } else {
+      instr.opPar = gen.u32();
+    }
+  }
+  if (!tpl.hasSrc) instr.src = -1;
+  if (!tpl.hasDst) instr.dst = -1;
+}
+
+function selectRegister(availableRegs: number[], regsCount: number, gen: SiphashRng): number {
+  if (regsCount === 0) return -1;
+  const index = regsCount > 1 ? gen.u32() % regsCount : 0;
+  return availableRegs[index]!;
+}
+
+function selectDestination(
+  tpl: InstrTemplate,
+  instr: Instruction,
+  ctx: GeneratorCtx,
+  cycle: number
+): boolean {
+  const availableRegs: number[] = new Array(8).fill(0);
+  let regsCount = 0;
+  for (let i = 0; i < 8; ++i) {
+    let available = ctx.registers[i]!.latency <= cycle;
+    available = available && (!tpl.distinctDst || i !== instr.src);
+    available =
+      available &&
+      (ctx.chainMul || tpl.group !== Op.MUL_R || ctx.registers[i]!.lastOp !== Op.MUL_R);
+    available =
+      available &&
+      (ctx.registers[i]!.lastOp !== tpl.group || ctx.registers[i]!.lastOpPar !== instr.opPar);
+    available = available && (instr.opcode !== Op.ADD_RS || i !== REGISTER_NEEDS_DISPLACEMENT);
+    availableRegs[regsCount] = available ? i : 0;
+    regsCount += available ? 1 : 0;
+  }
+  const reg = selectRegister(availableRegs, regsCount, ctx.gen);
+  if (reg < 0) return false;
+  instr.dst = reg;
+  return true;
+}
+
+function selectSource(
+  tpl: InstrTemplate,
+  instr: Instruction,
+  ctx: GeneratorCtx,
+  cycle: number
+): boolean {
+  const availableRegs: number[] = [];
+  let regsCount = 0;
+  for (let i = 0; i < 8; ++i) {
+    if (ctx.registers[i]!.latency <= cycle) availableRegs[regsCount++] = i;
+  }
+  if (regsCount === 2 && instr.opcode === Op.ADD_RS) {
+    if (
+      availableRegs[0] === REGISTER_NEEDS_DISPLACEMENT ||
+      availableRegs[1] === REGISTER_NEEDS_DISPLACEMENT
+    ) {
+      instr.opPar = instr.src = REGISTER_NEEDS_DISPLACEMENT;
+      return true;
+    }
+  }
+  const reg = selectRegister(availableRegs, regsCount, ctx.gen);
+  if (reg >= 0) {
+    instr.src = reg;
+    if (tpl.opParSrc) instr.opPar = instr.src;
+    return true;
+  }
+  return false;
+}
+
+function scheduleUop(uop: number, ctx: GeneratorCtx, cycleStart: number, commit: boolean): number {
+  for (let cycle = cycleStart; cycle < PORT_MAP_SIZE; ++cycle) {
+    const p = ctx.ports[cycle]!;
+    if (uop & PORT_P5 && !p[2]) {
+      if (commit) p[2] = uop;
+      return cycle;
+    }
+    if (uop & PORT_P0 && !p[0]) {
+      if (commit) p[0] = uop;
+      return cycle;
+    }
+    if ((uop & PORT_P1) !== 0 && !p[1]) {
+      if (commit) p[1] = uop;
+      return cycle;
+    }
+  }
+  return -1;
+}
+
+function scheduleInstr(tpl: InstrTemplate, ctx: GeneratorCtx, commit: boolean): number {
+  if (tpl.uop2 === PORT_NONE) {
+    return scheduleUop(tpl.uop1, ctx, ctx.cycle, commit);
+  }
+  for (let cycle = ctx.cycle; cycle < PORT_MAP_SIZE; ++cycle) {
+    const cycle1 = scheduleUop(tpl.uop1, ctx, cycle, false);
+    const cycle2 = scheduleUop(tpl.uop2, ctx, cycle, false);
+    if (cycle1 >= 0 && cycle1 === cycle2) {
+      if (commit) {
+        scheduleUop(tpl.uop1, ctx, cycle, true);
+        scheduleUop(tpl.uop2, ctx, cycle, true);
+      }
+      return cycle1;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Precompiled, execution-friendly form of a program: parallel typed arrays plus
+ * per-instruction BigInt constants. Built once per program and reused across
+ * the ~65536 executions a single Equi-X solve performs, avoiding per-instruction
+ * object-property and helper-call overhead in the hot loop.
+ */
+interface CompiledProgram {
+  ops: Uint8Array;
+  dst: Int8Array;
+  src: Int8Array;
+  bigA: bigint[]; // ADD_RS shift; ROR right amount; ADD_C/XOR_C sign-extended constant
+  bigB: bigint[]; // ROR left amount (64 - right)
+  brMask: Int32Array; // BRANCH imm32 mask
+  n: number;
+}
+
+/**
+ * A compiled HashX program: the instruction list plus the finalization keys.
+ * Produced by {@link hashxMake}; run with {@link hashxExecRegisters}.
+ */
+export interface HashxProgram {
+  code: Instruction[];
+  keys: SiphashState; // ctx->keys (keys[1]) — used for register init and finalization
+  /** Lazily-built precompiled form (see {@link CompiledProgram}). */
+  compiled?: CompiledProgram;
+}
+
+function compile(program: HashxProgram): CompiledProgram {
+  const code = program.code;
+  const n = code.length;
+  const ops = new Uint8Array(n);
+  const dst = new Int8Array(n);
+  const src = new Int8Array(n);
+  const brMask = new Int32Array(n);
+  const bigA: bigint[] = new Array(n).fill(0n);
+  const bigB: bigint[] = new Array(n).fill(0n);
+  for (let i = 0; i < n; i++) {
+    const ins = code[i]!;
+    ops[i] = ins.opcode;
+    dst[i] = ins.dst;
+    src[i] = ins.src;
+    switch (ins.opcode) {
+      case Op.ADD_RS:
+        bigA[i] = BigInt(ins.imm32);
+        break;
+      case Op.ROR_C:
+        bigA[i] = BigInt(ins.imm32);
+        bigB[i] = BigInt(64 - ins.imm32);
+        break;
+      case Op.ADD_C:
+      case Op.XOR_C:
+        bigA[i] = signExtend2sCompl(ins.imm32);
+        break;
+      case Op.BRANCH:
+        brMask[i] = ins.imm32 | 0;
+        break;
+    }
+  }
+  return { ops, dst, src, bigA, bigB, brMask, n };
+}
+
+/** hashx_program_generate — returns the program, or null if it fails the uniform-complexity requirement. */
+function programGenerate(key: SiphashState): Instruction[] | null {
+  const ctx: GeneratorCtx = {
+    cycle: 0,
+    subCycle: 0,
+    mulCount: 0,
+    chainMul: false,
+    latency: 0,
+    gen: new SiphashRng(key),
+    registers: Array.from({ length: 8 }, () => ({ latency: 0, lastOp: -1, lastOpPar: 0xffffffff })),
+    ports: Array.from({ length: PORT_MAP_SIZE }, () => new Int32Array(NUM_PORTS)),
+  };
+
+  const code: Instruction[] = [];
+  let attempt = 0;
+  let lastInstr = -1;
+
+  while (code.length < HASHX_PROGRAM_MAX_SIZE) {
+    const instr: Instruction = { opcode: Op.UMULH_R, src: -1, dst: -1, imm32: 0, opPar: 0 };
+
+    const tpl = selectTemplate(ctx, lastInstr, attempt);
+    lastInstr = tpl.group;
+
+    instrFromTemplate(tpl, ctx.gen, instr);
+
+    let scheduleCycle = scheduleInstr(tpl, ctx, false);
+    if (scheduleCycle < 0) break;
+
+    ctx.chainMul = attempt > 0;
+
+    if (tpl.hasSrc) {
+      if (!selectSource(tpl, instr, ctx, scheduleCycle)) {
+        if (attempt++ < MAX_RETRIES) continue;
+        ctx.subCycle += 3;
+        ctx.cycle = Math.floor(ctx.subCycle / 3);
+        attempt = 0;
+        continue;
+      }
+    }
+
+    if (tpl.hasDst) {
+      if (!selectDestination(tpl, instr, ctx, scheduleCycle)) {
+        if (attempt++ < MAX_RETRIES) continue;
+        ctx.subCycle += 3;
+        ctx.cycle = Math.floor(ctx.subCycle / 3);
+        attempt = 0;
+        continue;
+      }
+    }
+    attempt = 0;
+
+    scheduleCycle = scheduleInstr(tpl, ctx, true);
+    if (scheduleCycle < 0) break;
+    if (scheduleCycle >= TARGET_CYCLE) break;
+
+    if (tpl.hasDst) {
+      const ri = ctx.registers[instr.dst]!;
+      const retireCycle = scheduleCycle + tpl.latency;
+      ri.latency = retireCycle;
+      ri.lastOp = tpl.group;
+      ri.lastOpPar = instr.opPar;
+      ctx.latency = Math.max(retireCycle, ctx.latency);
+    }
+
+    code.push(instr);
+    ctx.mulCount += isMul(instr.opcode) ? 1 : 0;
+    ctx.subCycle++;
+    if (tpl.uop2 !== PORT_NONE) ctx.subCycle++;
+    ctx.cycle = Math.floor(ctx.subCycle / 3);
+  }
+
+  const ok =
+    code.length === REQUIREMENT_SIZE &&
+    ctx.mulCount === REQUIREMENT_MUL_COUNT &&
+    ctx.latency === REQUIREMENT_LATENCY - 1;
+  return ok ? code : null;
+}
+
+/** BLAKE2b parameter block salt used by HashX: the ASCII string "HashX v1" padded to 16 bytes. */
+const HASHX_SALT = (() => {
+  const s = new Uint8Array(16);
+  s.set(Buffer.from('HashX v1', 'ascii'));
+  return s;
+})();
+
+function readState(buf: Buffer, off: number): SiphashState {
+  return {
+    v0: buf.readBigUInt64LE(off),
+    v1: buf.readBigUInt64LE(off + 8),
+    v2: buf.readBigUInt64LE(off + 16),
+    v3: buf.readBigUInt64LE(off + 24),
+  };
+}
+
+/**
+ * hashx_make — derive a HashX program from a seed.
+ *
+ * @returns the compiled program, or null if the (rare, <1/10000) seed fails
+ *          the uniform-complexity requirement and must be rejected.
+ */
+export function hashxMake(seed: Buffer | Uint8Array): HashxProgram | null {
+  // blake2b(seed) with the HashX parameter block -> 64 bytes = two siphash states.
+  const keysBuf = blake2b(seed, { dkLen: 64, salt: HASHX_SALT });
+  const key0 = readState(keysBuf, 0);
+  const key1 = readState(keysBuf, 32);
+  const code = programGenerate(key0);
+  if (!code) return null;
+  return { code, keys: key1 };
+}
+
+function signExtend2sCompl(x: number): bigint {
+  // (int64_t)(int32_t)x
+  return u64(BigInt.asIntN(32, BigInt(x >>> 0)));
+}
+
+/**
+ * hashx_exec — run a HashX program over a 64-bit counter input and return the
+ * eight output registers already finalized. The Equi-X layer uses the first
+ * register pair (`out[0]`) as the 64-bit hash value; the full 32-byte digest
+ * is `out[0..3]` little-endian.
+ */
+export function hashxExecRegisters(program: HashxProgram, input: bigint): bigint[] {
+  const r = siphash24CtrState512(program.keys, u64(input));
+  const c = (program.compiled ??= compile(program));
+  const { ops, dst, src, bigA, bigB, brMask, n } = c;
+  const M = MASK64;
+
+  let target = 0;
+  let branchEnable = true;
+  let result = 0; // uint32 (bit pattern; only wide-mul updates it, per the reference)
+
+  for (let i = 0; i < n; ++i) {
+    const d = dst[i]!;
+    switch (ops[i]) {
+      case Op.UMULH_R: {
+        const v = ((r[d]! * r[src[i]!]!) >> 64n) & M;
+        r[d] = v;
+        result = Number(v & 0xffffffffn);
+        break;
+      }
+      case Op.SMULH_R: {
+        const a = BigInt.asIntN(64, r[d]!);
+        const b = BigInt.asIntN(64, r[src[i]!]!);
+        const v = ((a * b) >> 64n) & M;
+        r[d] = v;
+        result = Number(v & 0xffffffffn);
+        break;
+      }
+      case Op.MUL_R:
+        r[d] = (r[d]! * r[src[i]!]!) & M;
+        break;
+      case Op.SUB_R:
+        r[d] = (r[d]! - r[src[i]!]!) & M;
+        break;
+      case Op.XOR_R:
+        r[d] = r[d]! ^ r[src[i]!]!;
+        break;
+      case Op.ADD_RS:
+        r[d] = (r[d]! + ((r[src[i]!]! << bigA[i]!) & M)) & M;
+        break;
+      case Op.ROR_C: {
+        const x = r[d]!;
+        r[d] = ((x >> bigA[i]!) | (x << bigB[i]!)) & M;
+        break;
+      }
+      case Op.ADD_C:
+        r[d] = (r[d]! + bigA[i]!) & M;
+        break;
+      case Op.XOR_C:
+        r[d] = r[d]! ^ bigA[i]!;
+        break;
+      case Op.TARGET:
+        target = i;
+        break;
+      case Op.BRANCH:
+        if (branchEnable && (result & brMask[i]!) === 0) {
+          i = target;
+          branchEnable = false;
+        }
+        break;
+    }
+  }
+
+  // Finalization (hashx.c): add keys back in, two SipRounds, xor register pairs.
+  const k = program.keys;
+  r[0] = u64(r[0]! + k.v0);
+  r[1] = u64(r[1]! + k.v1);
+  r[6] = u64(r[6]! + k.v2);
+  r[7] = u64(r[7]! + k.v3);
+  const a = [r[0]!, r[1]!, r[2]!, r[3]!];
+  const b = [r[4]!, r[5]!, r[6]!, r[7]!];
+  sipround(a);
+  sipround(b);
+  return [a[0]! ^ b[0]!, a[1]! ^ b[1]!, a[2]! ^ b[2]!, a[3]! ^ b[3]!];
+}
+
+/** The 64-bit Equi-X hash value for an index (equivalent to C `load64(hashx_exec(...))`). */
+export function hashxExecValue(program: HashxProgram, input: bigint): bigint {
+  return hashxExecRegisters(program, input)[0]!;
+}
+
+/** The full 32-byte HashX digest (little-endian register pairs), used by the test vectors. */
+export function hashxExecDigest(program: HashxProgram, input: bigint): Buffer {
+  const out = hashxExecRegisters(program, input);
+  const buf = Buffer.alloc(32);
+  buf.writeBigUInt64LE(out[0]!, 0);
+  buf.writeBigUInt64LE(out[1]!, 8);
+  buf.writeBigUInt64LE(out[2]!, 16);
+  buf.writeBigUInt64LE(out[3]!, 24);
+  return buf;
+}

--- a/packages/crypto/src/pow/hspow.ts
+++ b/packages/crypto/src/pow/hspow.ts
@@ -1,0 +1,179 @@
+/**
+ * Hidden-service proof-of-work client (rend-spec / hspow-spec v1, "Equi-X and
+ * Blake2b"; proposal 327). Builds the Equi-X challenge from the descriptor's
+ * pow-params, solves it at a chosen effort, and validates the solution the same
+ * way the service will.
+ *
+ * Challenge:  P || ID || C || N || htonl(E)
+ *   P  = "Tor hs intro v1\0"          (16 bytes)
+ *   ID = blinded service identity key (32 bytes)
+ *   C  = pow-params seed              (32 bytes)
+ *   N  = nonce                        (16 bytes, little-endian counter)
+ *   E  = effort                       (uint32, network byte order)
+ *
+ * A solution is valid iff R * E <= UINT32_MAX where
+ *   R = ntohl(blake2b_32(challenge || solution_bytes)).
+ *
+ * Cross-checked against C Tor's hs_pow.c and its test vectors (see pow.spec.ts).
+ */
+
+import { blake2b } from '../hashes.ts';
+import { hashxMake } from './hashx.ts';
+import {
+  equixSolve,
+  packEquixSolution,
+  unpackEquixSolution,
+  equixVerify,
+  EquixResult,
+} from './equix.ts';
+
+export const HS_POW_PSTRING = 'Tor hs intro v1\0';
+const HS_POW_NONCE_LEN = 16;
+const HS_POW_SEED_LEN = 32;
+const HS_POW_ID_LEN = 32;
+const HS_POW_SEED_HEAD_LEN = 4;
+const HS_POW_HASH_LEN = 4;
+const UINT32_MAX = 0xffffffffn;
+
+const PSTRING = Buffer.from(HS_POW_PSTRING, 'ascii'); // 16 bytes incl. trailing NUL
+
+function buildChallenge(blindedId: Buffer, seed: Buffer, nonce: Buffer, effort: number): Buffer {
+  const e = Buffer.alloc(4);
+  e.writeUInt32BE(effort >>> 0);
+  return Buffer.concat([PSTRING, blindedId, seed, nonce, e]);
+}
+
+/** R = ntohl(blake2b_32(challenge || solution_bytes)) — big-endian read of a 4-byte BLAKE2b. */
+function powHashR(challenge: Buffer, solutionBytes: Buffer): number {
+  const h = blake2b(Buffer.concat([challenge, solutionBytes]), { dkLen: HS_POW_HASH_LEN });
+  return h.readUInt32BE(0);
+}
+
+/** Validate a solution against the effort target: R * E <= UINT32_MAX. */
+function validEffort(challenge: Buffer, solutionBytes: Buffer, effort: number): boolean {
+  const R = powHashR(challenge, solutionBytes);
+  return BigInt(R) * BigInt(effort >>> 0) <= UINT32_MAX;
+}
+
+/** Increment a 16-byte nonce as a little-endian integer, in place. */
+function incrementNonce(nonce: Buffer): void {
+  for (let i = 0; i < HS_POW_NONCE_LEN; i++) {
+    nonce[i] = (nonce[i]! + 1) & 0xff;
+    if (nonce[i] !== 0) break; // no carry out of this byte
+  }
+}
+
+/** The proof-of-work solution to embed in an INTRODUCE1 cell. */
+export interface HsPowSolution {
+  /** 16-byte nonce N. */
+  nonce: Buffer;
+  /** Effort E actually solved for. */
+  effort: number;
+  /** First 4 bytes of the seed C (POW_SEED). */
+  seedHead: Buffer;
+  /** 16-byte packed Equi-X solution (POW_SOLUTION). */
+  solution: Buffer;
+}
+
+export interface SolveHsPowOptions {
+  /** 32-byte pow-params seed C. */
+  seed: Buffer;
+  /** 32-byte blinded service identity key (KP_hs_blind_id). */
+  blindedId: Buffer;
+  /** Target effort E. Higher = more work and higher intro-queue priority. */
+  effort: number;
+  /** Random-bytes source (defaults injected by the crypto package export). */
+  randomBytes: (n: number) => Uint8Array;
+  /** Stop after this wall-clock time (ms). Default 60000. Returns null if exceeded. */
+  timeoutMs?: number;
+  /** Hard cap on nonces tried. Default: unlimited (bounded by timeoutMs). */
+  maxNonces?: number;
+  /** Progress callback: (noncesTried) each time a nonce is exhausted. */
+  onProgress?: (noncesTried: number) => void;
+  /** Monotonic clock, ms. Defaults to Date.now; injectable for tests. */
+  now?: () => number;
+  /**
+   * Cooperative yield between nonce attempts. Solving is CPU-bound and each
+   * nonce takes a noticeable slice of time, so on a single-threaded host (e.g.
+   * a browser service worker) this lets pending events run between attempts.
+   * Defaults to a macrotask yield (`setTimeout(0)`) when available, else a
+   * microtask.
+   */
+  yieldFn?: () => Promise<void>;
+}
+
+function defaultYield(): Promise<void> {
+  if (typeof setTimeout === 'function') {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  return Promise.resolve();
+}
+
+/**
+ * Solve the hidden-service PoW for a given seed/effort. Returns the solution to
+ * place in INTRODUCE1, or null if the budget (timeout / maxNonces) was
+ * exhausted before a solution at the requested effort was found.
+ *
+ * Effort 0 always succeeds on the first solution found (R * 0 == 0). Async and
+ * cooperative: it yields between nonce attempts so it doesn't monopolise a
+ * single-threaded event loop for the whole budget.
+ */
+export async function solveHsPow(opts: SolveHsPowOptions): Promise<HsPowSolution | null> {
+  if (opts.seed.length !== HS_POW_SEED_LEN)
+    throw new Error(`pow seed must be ${HS_POW_SEED_LEN} bytes`);
+  if (opts.blindedId.length !== HS_POW_ID_LEN)
+    throw new Error(`pow blindedId must be ${HS_POW_ID_LEN} bytes`);
+
+  const now = opts.now ?? Date.now;
+  const deadline = now() + (opts.timeoutMs ?? 60_000);
+  const maxNonces = opts.maxNonces ?? Number.POSITIVE_INFINITY;
+  const effort = opts.effort >>> 0;
+  const yieldFn = opts.yieldFn ?? defaultYield;
+
+  const nonce = Buffer.from(opts.randomBytes(HS_POW_NONCE_LEN));
+  let tried = 0;
+
+  while (tried < maxNonces && now() <= deadline) {
+    const challenge = buildChallenge(opts.blindedId, opts.seed, nonce, effort);
+    const program = hashxMake(challenge);
+    if (program) {
+      const sols = equixSolve(program);
+      for (const sol of sols) {
+        const solutionBytes = packEquixSolution(sol);
+        if (validEffort(challenge, solutionBytes, effort)) {
+          return {
+            nonce: Buffer.from(nonce),
+            effort,
+            seedHead: Buffer.from(opts.seed.subarray(0, HS_POW_SEED_HEAD_LEN)),
+            solution: solutionBytes,
+          };
+        }
+      }
+    }
+    tried++;
+    opts.onProgress?.(tried);
+    incrementNonce(nonce);
+    if (tried < maxNonces && now() <= deadline) {
+      await yieldFn();
+    }
+  }
+  return null;
+}
+
+/**
+ * Verify a hidden-service PoW solution end-to-end (Equi-X validity + effort).
+ * Mirrors the service-side check in hs_pow.c; used by tests and the HS host.
+ */
+export function verifyHsPow(params: {
+  seed: Buffer;
+  blindedId: Buffer;
+  nonce: Buffer;
+  effort: number;
+  solution: Buffer;
+}): boolean {
+  const challenge = buildChallenge(params.blindedId, params.seed, params.nonce, params.effort);
+  const program = hashxMake(challenge);
+  if (!program) return false;
+  if (equixVerify(program, unpackEquixSolution(params.solution)) !== EquixResult.OK) return false;
+  return validEffort(challenge, params.solution, params.effort);
+}

--- a/packages/crypto/src/pow/index.ts
+++ b/packages/crypto/src/pow/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Hidden-service proof-of-work (proposal 327 / hspow-spec v1: Equi-X + Blake2b).
+ *
+ * Pure-TypeScript port of the HashX + Equi-X reference implementations, plus
+ * the hspow client/verifier. Exposed through `tor-crypto` so both the Node and
+ * browser Tor clients can solve the PoW required by DoS-protected onion
+ * services.
+ */
+
+export { hashxMake, hashxExecValue, hashxExecDigest, type HashxProgram } from './hashx.ts';
+export {
+  equixSolve,
+  equixVerify,
+  packEquixSolution,
+  unpackEquixSolution,
+  EquixResult,
+  EQUIX_NUM_IDX,
+  EQUIX_MAX_SOLS,
+} from './equix.ts';
+export {
+  solveHsPow,
+  verifyHsPow,
+  HS_POW_PSTRING,
+  type HsPowSolution,
+  type SolveHsPowOptions,
+} from './hspow.ts';

--- a/packages/crypto/src/pow/pow.test.ts
+++ b/packages/crypto/src/pow/pow.test.ts
@@ -21,6 +21,7 @@ import {
   solveHsPow,
   verifyHsPow,
   randomBytes,
+  blake2b,
 } from 'tor-crypto';
 
 // Only run the full Equi-X solve (~a few seconds of BigInt work) under Node, so
@@ -191,6 +192,36 @@ describe('hspow client (C Tor test vectors)', () => {
           solution: sol!.solution,
         })
       ).toBe(true);
+    },
+    30_000
+  );
+
+  it.runIf(NODE)(
+    'rejects a structurally-valid Equi-X solution that misses the effort target',
+    () => {
+      // Distinct from the corrupted-nonce case (which fails at the Equi-X stage):
+      // here the solution IS a valid Equi-X solution (equixVerify == OK) but its
+      // R*E exceeds UINT32_MAX, so the effort check must reject it. Use the max
+      // effort so essentially every solution for the nonce misses the target.
+      const seed = Buffer.from('aa'.repeat(32), 'hex');
+      const blindedId = Buffer.from('11'.repeat(32), 'hex');
+      const nonce = Buffer.from('55'.repeat(16), 'hex');
+      const effort = 0xffffffff;
+      const ch = challenge('11'.repeat(32), 'aa'.repeat(32), '55'.repeat(16), effort);
+      const prog = hashxMake(ch)!;
+      let found = false;
+      for (const s of equixSolve(prog)) {
+        if (equixVerify(prog, s) !== EquixResult.OK) continue;
+        const solBytes = packEquixSolution(s);
+        const R = BigInt(blake2b(Buffer.concat([ch, solBytes]), { dkLen: 4 }).readUInt32BE(0));
+        if (R * BigInt(effort) <= 0xffffffffn) continue; // this one happens to meet the target
+        // Valid Equi-X solution, but effort target missed -> verifyHsPow must reject.
+        expect(equixVerify(prog, s)).toBe(EquixResult.OK);
+        expect(verifyHsPow({ seed, blindedId, nonce, effort, solution: solBytes })).toBe(false);
+        found = true;
+        break;
+      }
+      expect(found).toBe(true);
     },
     30_000
   );

--- a/packages/crypto/src/pow/pow.test.ts
+++ b/packages/crypto/src/pow/pow.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for the hidden-service proof-of-work primitives (HashX + Equi-X + the
+ * hspow client), validated against the reference implementations and C Tor.
+ *
+ * Sources of the vectors:
+ *  - HashX digests: tevador/hashx `src/tests.c`.
+ *  - Equi-X golden solver output: generated from tevador/equix's reference
+ *    solver for a fixed challenge (deterministic).
+ *  - hspow verification vectors: C Tor `src/test/test_hs_pow.c`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  hashxMake,
+  hashxExecDigest,
+  equixSolve,
+  equixVerify,
+  EquixResult,
+  packEquixSolution,
+  unpackEquixSolution,
+  solveHsPow,
+  verifyHsPow,
+  randomBytes,
+} from 'tor-crypto';
+
+// Only run the full Equi-X solve (~a few seconds of BigInt work) under Node, so
+// the browser suite stays fast. The verification-only tests run everywhere.
+const NODE = typeof process !== 'undefined' && !!process.versions?.node;
+
+const P = Buffer.from('Tor hs intro v1\0', 'ascii');
+function challenge(idHex: string, seedHex: string, nonceHex: string, effort: number): Buffer {
+  const e = Buffer.alloc(4);
+  e.writeUInt32BE(effort >>> 0);
+  return Buffer.concat([
+    P,
+    Buffer.from(idHex, 'hex'),
+    Buffer.from(seedHex, 'hex'),
+    Buffer.from(nonceHex, 'hex'),
+    e,
+  ]);
+}
+
+describe('HashX', () => {
+  const vectors: Array<[string, bigint, string]> = [
+    [
+      'This is a test\0',
+      123456n,
+      'aebdd50aa67c93afb82a4c534603b65e46decd584c55161c526ebc099415ccf1',
+    ],
+    ['This is a test\0', 0n, '2b2f54567dcbea98fdb5d5e5ce9a65983c4a4e35ab1464b1efb61e83b7074bb2'],
+    [
+      'Lorem ipsum dolor sit amet\0',
+      123456n,
+      'ab3d155bf4bbb0aa3a71b7801089826186e44300e6932e6ffd287cf302bbb0ba',
+    ],
+    [
+      'Lorem ipsum dolor sit amet\0',
+      987654321123456789n,
+      '8dfef0497c323274a60d1d93292b68d9a0496379ba407b4341cf868a14d30113',
+    ],
+  ];
+  for (const [seed, ctr, expected] of vectors) {
+    it(`matches reference digest for seed=${JSON.stringify(seed)} ctr=${ctr}`, () => {
+      const prog = hashxMake(Buffer.from(seed, 'ascii'));
+      expect(prog).not.toBeNull();
+      expect(hashxExecDigest(prog!, ctr).toString('hex')).toBe(expected);
+    });
+  }
+});
+
+describe('Equi-X', () => {
+  // Golden challenge: P || id(0x11*32) || seed(0xaa*32) || nonce(0x55*16) || htonl(0)
+  const goldenChallenge = challenge('11'.repeat(32), 'aa'.repeat(32), '55'.repeat(16), 0);
+  const goldenSolutions = [
+    '4312f87ceab844c78e1c793a913812d7',
+    'a15e4ca0410d26aa0d3587464c0f90f0',
+    'ac2cc635264b6d8d5f5ed677f6069fd8',
+    '3f5f1090ea7576b5631ab51cd4256dd5',
+    '4d51c17d5b462ab4ce32e748687caece',
+    '075ae97ab4b065b2c42a8069e6007ad6',
+  ];
+
+  it.runIf(NODE)('solver reproduces the reference solutions in order', () => {
+    const prog = hashxMake(goldenChallenge)!;
+    const sols = equixSolve(prog).map((s) => packEquixSolution(s).toString('hex'));
+    expect(sols).toEqual(goldenSolutions);
+  });
+
+  it.runIf(NODE)('every found solution verifies as OK', () => {
+    const prog = hashxMake(goldenChallenge)!;
+    for (const s of equixSolve(prog)) {
+      expect(equixVerify(prog, s)).toBe(EquixResult.OK);
+    }
+  });
+
+  it('verifies a known-good solution and rejects reordered indices', () => {
+    const prog = hashxMake(goldenChallenge)!;
+    const idx = unpackEquixSolution(Buffer.from(goldenSolutions[0]!, 'hex'));
+    expect(equixVerify(prog, idx)).toBe(EquixResult.OK);
+    // Swapping the first pair breaks canonical ordering.
+    const swapped = Uint16Array.from(idx);
+    [swapped[0], swapped[1]] = [swapped[1]!, swapped[0]!];
+    expect(equixVerify(prog, swapped)).toBe(EquixResult.ORDER);
+  });
+
+  it('pack/unpack round-trips', () => {
+    const idx = unpackEquixSolution(Buffer.from(goldenSolutions[2]!, 'hex'));
+    expect(packEquixSolution(idx).toString('hex')).toBe(goldenSolutions[2]);
+  });
+});
+
+describe('hspow client (C Tor test vectors)', () => {
+  // From src/test/test_hs_pow.c: (blinded_id, seed, nonce, effort, solution).
+  const valid = [
+    {
+      name: 'zero-effort',
+      id: '11'.repeat(32),
+      seed: 'aa'.repeat(32),
+      nonce: '55'.repeat(16),
+      effort: 0,
+      solution: '4312f87ceab844c78e1c793a913812d7',
+    },
+    {
+      name: 'high-effort (1e6)',
+      id: '11'.repeat(32),
+      seed: 'aa'.repeat(32),
+      nonce: '59217255555555555555555555555555',
+      effort: 1000000,
+      solution: '0f3db97b9cac20c1771680a1a34848d3',
+    },
+    {
+      name: 'real keys (1e5)',
+      id: 'bfd298428562e530c52bdb36d81a0e293ef4a0e94d787f0f8c0c611f4f9e78ed',
+      seed: '86fb0acf4932cda44dbb451282f415479462dd10cb97ff5e7e8e2a53c3767a7f',
+      nonce: '2eff9fdbc34326d9d2f18ed277469c63',
+      effort: 100000,
+      solution: '400cb091139f86b352119f6e131802d6',
+    },
+  ];
+
+  for (const v of valid) {
+    it(`verifies ${v.name}`, () => {
+      expect(
+        verifyHsPow({
+          seed: Buffer.from(v.seed, 'hex'),
+          blindedId: Buffer.from(v.id, 'hex'),
+          nonce: Buffer.from(v.nonce, 'hex'),
+          effort: v.effort,
+          solution: Buffer.from(v.solution, 'hex'),
+        })
+      ).toBe(true);
+    });
+  }
+
+  it('rejects a corrupted nonce', () => {
+    expect(
+      verifyHsPow({
+        seed: Buffer.from(
+          '86fb0acf4932cda44dbb451282f415479462dd10cb97ff5e7e8e2a53c3767a7f',
+          'hex'
+        ),
+        blindedId: Buffer.from(
+          'bfd298428562e530c52bdb36d81a0e293ef4a0e94d787f0f8c0c611f4f9e78ed',
+          'hex'
+        ),
+        // one nibble flipped vs the valid vector above
+        nonce: Buffer.from('2eff9fdbc34326d9a2f18ed277469c63', 'hex'),
+        effort: 100000,
+        solution: Buffer.from('400cb091139f86b352119f6e131802d6', 'hex'),
+      })
+    ).toBe(false);
+  });
+
+  it.runIf(NODE)(
+    'solves an effort-0 puzzle that round-trips through verification',
+    async () => {
+      const seed = Buffer.from('aa'.repeat(32), 'hex');
+      const blindedId = Buffer.from('11'.repeat(32), 'hex');
+      const sol = await solveHsPow({ seed, blindedId, effort: 0, randomBytes });
+      expect(sol).not.toBeNull();
+      expect(sol!.seedHead.toString('hex')).toBe('aaaaaaaa');
+      expect(
+        verifyHsPow({
+          seed,
+          blindedId,
+          nonce: sol!.nonce,
+          effort: sol!.effort,
+          solution: sol!.solution,
+        })
+      ).toBe(true);
+    },
+    30_000
+  );
+
+  it.runIf(NODE)('respects the solve budget and returns null when exhausted', async () => {
+    // A huge effort with a 1-nonce budget cannot be met -> null (no throw).
+    const sol = await solveHsPow({
+      seed: Buffer.from('aa'.repeat(32), 'hex'),
+      blindedId: Buffer.from('11'.repeat(32), 'hex'),
+      effort: 0xffffffff,
+      randomBytes,
+      maxNonces: 1,
+    });
+    expect(sol).toBeNull();
+  });
+});

--- a/packages/crypto/src/pow/pow.test.ts
+++ b/packages/crypto/src/pow/pow.test.ts
@@ -25,7 +25,10 @@ import {
 
 // Only run the full Equi-X solve (~a few seconds of BigInt work) under Node, so
 // the browser suite stays fast. The verification-only tests run everywhere.
-const NODE = typeof process !== 'undefined' && !!process.versions?.node;
+// Require the absence of `window` too: the browser build polyfills `process`,
+// so `process.versions.node` alone can be truthy there.
+const NODE =
+  typeof window === 'undefined' && typeof process !== 'undefined' && !!process.versions?.node;
 
 const P = Buffer.from('Tor hs intro v1\0', 'ascii');
 function challenge(idHex: string, seedHex: string, nonceHex: string, effort: number): Buffer {

--- a/packages/tor/src/build-circuit/directory.spec.ts
+++ b/packages/tor/src/build-circuit/directory.spec.ts
@@ -13,7 +13,7 @@ valid-after 2024-01-01 00:00:00
 fresh-until 2024-01-01 01:00:00
 valid-until 2024-01-01 03:00:00
 voting-delay 300 300
-params bwweightscale=10000 hsdir-interval=1440
+params bwweightscale=10000 hsdir_interval=1440
 shared-rand-previous-value 3 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
 shared-rand-current-value 3 BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=
 r TestRelay1 AB+0S6hvSEnm7ifzqh3QaYOxsm0 2024-01-01 00:00:00 192.168.1.1 9001 9030
@@ -82,7 +82,7 @@ test('parseMicroDescConsensus: parses consensus metadata', (t) => {
   t.truthy(consensus.validUntil);
 
   t.is(consensus.params['bwweightscale'], 10000);
-  t.is(consensus.params['hsdir-interval'], 1440);
+  t.is(consensus.params['hsdir_interval'], 1440);
 
   t.truthy(consensus.sharedRandPreviousValue);
   t.truthy(consensus.sharedRandCurrentValue);

--- a/packages/tor/src/build-circuit/node-client.ts
+++ b/packages/tor/src/build-circuit/node-client.ts
@@ -127,11 +127,18 @@ export async function makeNodejsTorClient(
   channelManager.add(guardPeerInfo.rsaIdDigest, guardChannel);
 
   // Build circuit to a specific target (for hidden services)
-  const buildCircuitToTarget: BuildCircuitFn = async (target) => {
+  const buildCircuitToTarget: BuildCircuitFn = async (target, opts) => {
+    // Honor the caller's avoid list. The HS flow builds the introduction
+    // circuit with `{ avoid: [rendezvousPoint] }` so the same relay can't serve
+    // as both the rendezvous point and a hop on the intro circuit — reusing it
+    // makes the service drop the introduction. Also exclude the target itself
+    // and our fixed guard so the middle hop is always distinct.
+    const avoidDigests = (opts?.avoid ?? []).map((p) => p.rsaIdDigest);
     const candidateRelays = consensus.relays.filter(
       (r) =>
         !r.rsaIdDigest.equals(target.rsaIdDigest) &&
-        !r.rsaIdDigest.equals(guardPeerInfo.rsaIdDigest)
+        !r.rsaIdDigest.equals(guardPeerInfo.rsaIdDigest) &&
+        !avoidDigests.some((d) => d.equals(r.rsaIdDigest))
     );
     const middleNode = pickRelayWithFlags(candidateRelays, ['Stable'], []);
     const middlePeerInfo = await lookupPeerInfo(dirClient, middleNode);

--- a/packages/tor/src/circuit.ts
+++ b/packages/tor/src/circuit.ts
@@ -841,12 +841,23 @@ export class Circuit extends EventEmitter {
         stream.connectionLatch.resolve();
         return;
       }
+      // Hidden-service relay commands are handled by callers (client or host)
+      // listening on the circuit's 'relay' event, which is emitted above before
+      // this switch runs. Enumerating them here as explicit no-ops keeps the
+      // `default` branch for genuinely unknown commands — otherwise a hosting
+      // circuit receiving INTRODUCE2 / RENDEZVOUS1 / a rendezvous-side BEGIN
+      // throws "unknown relay message type", which is caught and logged but
+      // reads like a real failure in the logs.
+      case RelayCell.BEGIN: // service opens app streams on the rendezvous circuit
+      case RelayCell.ESTABLISH_INTRO:
+      case RelayCell.ESTABLISH_RENDEZVOUS:
+      case RelayCell.INTRODUCE1:
+      case RelayCell.INTRODUCE2:
+      case RelayCell.RENDEZVOUS1:
       case RelayCell.RENDEZVOUS_ESTABLISHED:
       case RelayCell.RENDEZVOUS2:
       case RelayCell.INTRODUCE_ACK:
       case RelayCell.INTRO_ESTABLISHED: {
-        // Hidden service relay commands are handled by callers listening on
-        // the circuit's 'relay' event.
         return;
       }
       case RelayCell.RESOLVED: {

--- a/packages/tor/src/hidden-service.spec.ts
+++ b/packages/tor/src/hidden-service.spec.ts
@@ -1,4 +1,5 @@
 import test from 'ava';
+import { aes256CtrXor } from 'tor-crypto';
 import {
   parseOnionV3Address,
   isOnionAddress,
@@ -15,8 +16,12 @@ import {
   hsBuildHsIndex,
   hsBuildHsdirIndex,
   isHsDebugEnabled,
+  buildIntroduce1Payload,
+  hsNtorDeriveEncAndMac,
   type HsdirCandidate,
 } from './hidden-service.ts';
+import { LinkSpecifierTypes } from './messaging.ts';
+import type { PeerInfo } from './circuit.ts';
 
 // Facebook's v3 onion address (well-known, used for testing)
 const FACEBOOK_ONION = 'facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd';
@@ -752,4 +757,62 @@ test('isHsDebugEnabled: honors the TOR_TS_HS_DEBUG env var', (t) => {
     if (prevEnv === undefined) delete process.env.TOR_TS_HS_DEBUG;
     else process.env.TOR_TS_HS_DEBUG = prevEnv;
   }
+});
+
+// =========================================================================
+// INTRODUCE1 proof-of-work extension serialization
+// =========================================================================
+// Pins the exact wire bytes of the PoW extension (proposal 327): the service
+// parses EXT_FIELD_TYPE=2 || EXT_FIELD_LEN || POW_VERSION(1) || POW_NONCE(16) ||
+// POW_EFFORT(4, big-endian) || POW_SEED(4) || POW_SOLUTION(16). A regression in
+// field order/size/endianness would silently break every PoW-enabled intro and
+// surface only as a rendezvous timeout, so assert the decrypted plaintext here.
+test('buildIntroduce1Payload: serializes the PoW extension per spec', async (t) => {
+  const proofOfWork = {
+    scheme: 1,
+    nonce: Buffer.from('0123456789abcdef0123456789abcdef', 'hex'),
+    effort: 1000000, // 0x000f4240
+    seed: Buffer.from('deadbeef', 'hex'),
+    solution: Buffer.from('00112233445566778899aabbccddeeff', 'hex'),
+  };
+  const rendezvousPoint: PeerInfo = {
+    onionKey: Buffer.alloc(32, 7),
+    rsaIdDigest: Buffer.alloc(20, 3),
+    linkSpecifiers: [{ type: LinkSpecifierTypes.LegacyId, data: Buffer.alloc(20, 3) }],
+  };
+
+  const { payload, state } = await buildIntroduce1Payload({
+    introAuthKeyEd25519: Buffer.alloc(32, 1),
+    serviceEncKey: Buffer.alloc(32, 2),
+    N_hs_subcred: Buffer.alloc(32, 4),
+    rendezvousCookie: Buffer.alloc(20, 9),
+    rendezvousPoint,
+    proofOfWork,
+  });
+
+  // payload = header(56) | CLIENT_PK/X(32) | ciphertext | MAC(32)
+  const headerLen = 20 + 1 + 2 + 32 + 1;
+  const ciphertext = payload.subarray(headerLen + 32, payload.length - 32);
+
+  // Re-derive ENC_KEY from the handshake state and decrypt the ENCRYPTED section.
+  const { ENC_KEY } = hsNtorDeriveEncAndMac(state);
+  const plain = Buffer.from(await aes256CtrXor(ENC_KEY, Buffer.alloc(16, 0), ciphertext));
+
+  let o = 0;
+  o += 20; // RENDEZVOUS_COOKIE
+  const nExt = plain[o]!;
+  o += 1;
+  t.is(nExt, 1, 'exactly one extension (PoW)');
+  const extType = plain[o]!;
+  o += 1;
+  const extLen = plain[o]!;
+  o += 1;
+  t.is(extType, 0x02, 'EXT_FIELD_TYPE = PROOF_OF_WORK');
+  t.is(extLen, 41, 'EXT_FIELD_LEN = 1+16+4+4+16');
+  const body = plain.subarray(o, o + extLen);
+  t.is(body[0], 1, 'POW_VERSION = 1');
+  t.deepEqual(body.subarray(1, 17), proofOfWork.nonce, 'POW_NONCE');
+  t.is(body.readUInt32BE(17), proofOfWork.effort, 'POW_EFFORT (big-endian)');
+  t.deepEqual(body.subarray(21, 25), proofOfWork.seed, 'POW_SEED (4-byte seed head)');
+  t.deepEqual(body.subarray(25, 41), proofOfWork.solution, 'POW_SOLUTION');
 });

--- a/packages/tor/src/hidden-service.spec.ts
+++ b/packages/tor/src/hidden-service.spec.ts
@@ -14,6 +14,7 @@ import {
   toBase64NoPad,
   hsBuildHsIndex,
   hsBuildHsdirIndex,
+  isHsDebugEnabled,
   type HsdirCandidate,
 } from './hidden-service.ts';
 
@@ -708,4 +709,47 @@ test('computeDisasterSrv: format matches spec', (t) => {
     periodNum: 43n,
   });
   t.notDeepEqual(srv, srv3, 'different period should give different disaster SRV');
+});
+
+test('isHsDebugEnabled: honors the browser-style globalThis flag', (t) => {
+  const g = globalThis as { __TOR_TS_HS_DEBUG__?: boolean };
+  const prev = g.__TOR_TS_HS_DEBUG__;
+  const prevEnv = process.env.TOR_TS_HS_DEBUG;
+  // Isolate from any ambient env var so we exercise the globalThis path.
+  delete process.env.TOR_TS_HS_DEBUG;
+  try {
+    delete g.__TOR_TS_HS_DEBUG__;
+    t.false(isHsDebugEnabled(), 'disabled when neither env nor global flag set');
+
+    g.__TOR_TS_HS_DEBUG__ = true;
+    t.true(isHsDebugEnabled(), 'enabled when global flag is true (browser/service-worker path)');
+
+    g.__TOR_TS_HS_DEBUG__ = false;
+    t.false(isHsDebugEnabled(), 'disabled when global flag is false');
+  } finally {
+    if (prev === undefined) delete g.__TOR_TS_HS_DEBUG__;
+    else g.__TOR_TS_HS_DEBUG__ = prev;
+    if (prevEnv === undefined) delete process.env.TOR_TS_HS_DEBUG;
+    else process.env.TOR_TS_HS_DEBUG = prevEnv;
+  }
+});
+
+test('isHsDebugEnabled: honors the TOR_TS_HS_DEBUG env var', (t) => {
+  const g = globalThis as { __TOR_TS_HS_DEBUG__?: boolean };
+  const prevGlobal = g.__TOR_TS_HS_DEBUG__;
+  const prevEnv = process.env.TOR_TS_HS_DEBUG;
+  delete g.__TOR_TS_HS_DEBUG__;
+  try {
+    process.env.TOR_TS_HS_DEBUG = '1';
+    t.true(isHsDebugEnabled(), "enabled for '1'");
+    process.env.TOR_TS_HS_DEBUG = 'true';
+    t.true(isHsDebugEnabled(), "enabled for 'true'");
+    process.env.TOR_TS_HS_DEBUG = '0';
+    t.false(isHsDebugEnabled(), "disabled for '0'");
+  } finally {
+    if (prevGlobal === undefined) delete g.__TOR_TS_HS_DEBUG__;
+    else g.__TOR_TS_HS_DEBUG__ = prevGlobal;
+    if (prevEnv === undefined) delete process.env.TOR_TS_HS_DEBUG;
+    else process.env.TOR_TS_HS_DEBUG = prevEnv;
+  }
 });

--- a/packages/tor/src/hidden-service.ts
+++ b/packages/tor/src/hidden-service.ts
@@ -13,6 +13,8 @@ import {
   dMac,
   bytesToBigIntLE,
   createSha3_256Hash,
+  // rend-spec-v3 hidden-service proof-of-work (proposal 327 / hspow-spec):
+  solveHsPow,
 } from 'tor-crypto';
 import { BytesReader, shuffleInPlace } from './util.ts';
 import { type LinkSpecifier, LinkSpecifierTypes, RELAY_PAYLOAD_LEN } from './messaging.ts';
@@ -303,6 +305,25 @@ export interface HsConnectionOptions {
    * If provided, descriptors will be cached and reused across connection attempts.
    */
   descriptorCache?: HsDescriptorCache;
+  /**
+   * Disable the proof-of-work client. When a service advertises `pow-params`
+   * with a non-zero suggested effort, the client solves an Equi-X puzzle
+   * (proposal 327) and attaches it to INTRODUCE1. Set this to skip that — the
+   * introduction is then sent without a PoW token (likely dropped by a service
+   * actively enforcing PoW).
+   */
+  disablePow?: boolean;
+  /**
+   * Upper bound on the PoW effort to attempt, regardless of the service's
+   * suggested effort. Solving cost scales roughly linearly with effort, so this
+   * caps worst-case CPU time. Default: the descriptor's suggested effort.
+   */
+  maxPowEffort?: number;
+  /**
+   * Wall-clock budget for solving the PoW, in ms (default 60000). If exceeded,
+   * the introduction is sent without a PoW token rather than blocking forever.
+   */
+  powTimeoutMs?: number;
 }
 
 /**
@@ -1983,6 +2004,9 @@ export async function connectToHiddenServiceCore(
     randomBytes: randomBytesOpt = randomBytes,
     iptExperienceTracker,
     descriptorCache,
+    disablePow = false,
+    maxPowEffort,
+    powTimeoutMs = 60_000,
   } = options;
   const dlog = makeHsDebugLog(log);
 
@@ -2178,24 +2202,26 @@ export async function connectToHiddenServiceCore(
 
   log(`Found ${descriptor.introPoints.length} introduction point(s)`);
 
-  // Proof-of-work gate (proposal 327 / rend-spec-v3 §3.4.1). When a service is
-  // under DoS defense it advertises `pow-params` with a non-zero suggested
-  // effort and its intro points prioritise the pending-rendezvous queue by the
-  // client's PoW effort. We parse pow-params but do NOT yet solve the Equi-X
-  // puzzle, so our INTRODUCE1 carries no PoW token. Against a service that is
-  // actively enforcing PoW this means the introduction is deprioritised and,
-  // under real load, dropped — surfacing later as a RENDEZVOUS2 timeout. This
-  // is the most likely reason a service reachable in Tor Browser (which solves
-  // the puzzle) fails here. Surface it loudly so it's diagnosable rather than a
-  // silent timeout. See https://spec.torproject.org/hspow-spec.
-  if (descriptor.powParams && descriptor.powParams.suggestedEffort > 0) {
+  // Proof-of-work gate (proposal 327 / hspow-spec v1). When a service is under
+  // DoS defense it advertises `pow-params` with a non-zero suggested effort and
+  // its intro points prioritise the pending-rendezvous queue by the client's
+  // PoW effort. We solve the Equi-X puzzle (below, per intro attempt) and attach
+  // it to INTRODUCE1. A request arriving with no PoW token — or too little
+  // effort — is deprioritised and, under real load, dropped, surfacing as a
+  // RENDEZVOUS2 timeout. See https://spec.torproject.org/hspow-spec.
+  const powRequired =
+    !disablePow && descriptor.powParams !== undefined && descriptor.powParams.suggestedEffort > 0;
+  if (descriptor.powParams && descriptor.powParams.suggestedEffort > 0 && disablePow) {
     log(
-      `WARNING: hidden service advertises proof-of-work (scheme=${descriptor.powParams.scheme}, ` +
-        `suggested-effort=${descriptor.powParams.suggestedEffort}). tor-ts does not implement the ` +
-        `Equi-X PoW client yet, so INTRODUCE1 will be sent without a PoW token. If the service is ` +
-        `enforcing PoW under load the introduction may be dropped, causing a rendezvous timeout. ` +
-        `This is a known limitation (services under active DoS protection connect in Tor Browser ` +
-        `but not here).`
+      `Hidden service requests proof-of-work (suggested-effort=` +
+        `${descriptor.powParams.suggestedEffort}) but PoW is disabled; sending introduction ` +
+        `without a PoW token (may be dropped by a service enforcing PoW).`
+    );
+  } else if (powRequired) {
+    log(
+      `Hidden service requests proof-of-work (scheme=${descriptor.powParams!.scheme}, ` +
+        `suggested-effort=${descriptor.powParams!.suggestedEffort}); will solve an Equi-X puzzle ` +
+        `for each introduction attempt.`
     );
   }
 
@@ -2264,6 +2290,40 @@ export async function connectToHiddenServiceCore(
       const introPeer = peerInfoFromIntroPoint(intro);
       introCircuit = await buildCircuit(introPeer, { avoid: [rendezvousPoint] });
 
+      // Solve proof-of-work for this attempt (fresh nonce each time, so a retry
+      // to another intro point is never rejected as a replay by the service).
+      let proofOfWork: BuildIntroduce1Params['proofOfWork'] | undefined;
+      if (powRequired && descriptor.powParams) {
+        const effort =
+          maxPowEffort !== undefined
+            ? Math.min(descriptor.powParams.suggestedEffort, maxPowEffort)
+            : descriptor.powParams.suggestedEffort;
+        const powStart = Date.now();
+        log(`Solving proof-of-work (effort=${effort})...`);
+        const solved = await solveHsPow({
+          seed: descriptor.powParams.seed,
+          blindedId: blindedPublicKey,
+          effort,
+          randomBytes: randomBytesOpt,
+          timeoutMs: powTimeoutMs,
+        });
+        if (solved) {
+          log(`Proof-of-work solved in ${Date.now() - powStart}ms (effort=${solved.effort})`);
+          proofOfWork = {
+            scheme: 1, // v1 (Equi-X)
+            nonce: solved.nonce,
+            effort: solved.effort,
+            seed: solved.seedHead,
+            solution: solved.solution,
+          };
+        } else {
+          log(
+            `Proof-of-work not solved within ${powTimeoutMs}ms; sending introduction without a ` +
+              `PoW token (may be dropped by a service enforcing PoW).`
+          );
+        }
+      }
+
       log(`Sending introduction (attempt ${attempt + 1}/${maxIntroAttempts})...`);
       const { payload: introducePayload, state } = await buildIntroduce1Payload({
         introAuthKeyEd25519: intro.authKeyEd25519,
@@ -2271,6 +2331,7 @@ export async function connectToHiddenServiceCore(
         N_hs_subcred: subcred,
         rendezvousCookie,
         rendezvousPoint,
+        ...(proofOfWork && { proofOfWork }),
       });
 
       await introCircuit.sendRelayMessage({

--- a/packages/tor/src/hidden-service.ts
+++ b/packages/tor/src/hidden-service.ts
@@ -55,15 +55,32 @@ const INTRO1_TARGET_LEN = Math.min(
  * for the case where the caller *did* wire a log sink and we want to keep
  * routine flows quiet there too.
  */
-const HS_DEBUG_ENABLED = ((): boolean => {
+/**
+ * Whether verbose HS diagnostics are currently enabled.
+ *
+ * Evaluated per-call (not cached at module load) so it can be toggled at
+ * runtime. This matters in the browser / service-worker, where there is no
+ * `process.env`: the browser Tor client sets `globalThis.__TOR_TS_HS_DEBUG__`
+ * when created with `{ debug: true }`, which turns these logs on without a
+ * rebuild.
+ *
+ * Enabled when either:
+ *   - Node:    `process.env.TOR_TS_HS_DEBUG` is `'1'` or `'true'`, or
+ *   - Browser: `globalThis.__TOR_TS_HS_DEBUG__ === true`.
+ */
+export function isHsDebugEnabled(): boolean {
+  const g = globalThis as { __TOR_TS_HS_DEBUG__?: boolean };
+  if (g.__TOR_TS_HS_DEBUG__ === true) return true;
   const v =
     typeof process !== 'undefined' && process?.env ? process.env.TOR_TS_HS_DEBUG : undefined;
   if (v === undefined) return false;
   return v === '1' || v.toLowerCase() === 'true';
-})();
+}
 
 function makeHsDebugLog(log: (msg: string) => void): (msg: string) => void {
-  return HS_DEBUG_ENABLED ? log : () => {};
+  return (msg: string) => {
+    if (isHsDebugEnabled()) log(msg);
+  };
 }
 
 // ============================================================================
@@ -457,7 +474,13 @@ export function computeTimePeriodInfo(
     throw new Error('Consensus missing valid-after; cannot compute HS time period');
   }
 
-  const hsdirInterval = consensus.params['hsdir-interval'] ?? 1440;
+  // Consensus params use underscores (`hsdir_interval`), matching C Tor's
+  // networkstatus param names. An earlier hyphenated lookup (`hsdir-interval`)
+  // always missed and silently fell back to 1440 — harmless while authorities
+  // never voted a non-default value, but a latent correctness bug that would
+  // pick the wrong time period (and thus the wrong blinded key / HSDirs) the
+  // moment they did.
+  const hsdirInterval = consensus.params['hsdir_interval'] ?? 1440;
 
   // Use CURRENT time for period calculation, but consensus for voting interval derivation
   const timeArgs: Parameters<typeof computeTimePeriod>[0] = { validAfter: currentTime };
@@ -467,10 +490,10 @@ export function computeTimePeriodInfo(
     timeArgs.freshUntil = new Date(currentTime.getTime() + votingIntervalMs);
   }
 
-  // On mainnet, hsdir-interval == derived (votingIntervalSec * 24)/60 because the voting interval is 1h.
-  // On testing networks (including Chutney), Tor ignores hsdir-interval and derives the period length from
+  // On mainnet, hsdir_interval == derived (votingIntervalSec * 24)/60 because the voting interval is 1h.
+  // On testing networks (including Chutney), Tor ignores hsdir_interval and derives the period length from
   // the voting interval, which is typically much shorter than 1h. To match Tor behavior across both cases,
-  // only pass hsdir-interval when it matches the derived value; otherwise let computeTimePeriod derive it.
+  // only pass hsdir_interval when it matches the derived value; otherwise let computeTimePeriod derive it.
   const votingIntervalSec = consensus.freshUntil
     ? Math.floor((consensus.freshUntil.getTime() - consensus.validAfter.getTime()) / 1000)
     : 3600;
@@ -2154,6 +2177,27 @@ export async function connectToHiddenServiceCore(
   const rendezvousPoint = await rendezvousPointPromise;
 
   log(`Found ${descriptor.introPoints.length} introduction point(s)`);
+
+  // Proof-of-work gate (proposal 327 / rend-spec-v3 §3.4.1). When a service is
+  // under DoS defense it advertises `pow-params` with a non-zero suggested
+  // effort and its intro points prioritise the pending-rendezvous queue by the
+  // client's PoW effort. We parse pow-params but do NOT yet solve the Equi-X
+  // puzzle, so our INTRODUCE1 carries no PoW token. Against a service that is
+  // actively enforcing PoW this means the introduction is deprioritised and,
+  // under real load, dropped — surfacing later as a RENDEZVOUS2 timeout. This
+  // is the most likely reason a service reachable in Tor Browser (which solves
+  // the puzzle) fails here. Surface it loudly so it's diagnosable rather than a
+  // silent timeout. See https://spec.torproject.org/hspow-spec.
+  if (descriptor.powParams && descriptor.powParams.suggestedEffort > 0) {
+    log(
+      `WARNING: hidden service advertises proof-of-work (scheme=${descriptor.powParams.scheme}, ` +
+        `suggested-effort=${descriptor.powParams.suggestedEffort}). tor-ts does not implement the ` +
+        `Equi-X PoW client yet, so INTRODUCE1 will be sent without a PoW token. If the service is ` +
+        `enforcing PoW under load the introduction may be dropped, causing a rendezvous timeout. ` +
+        `This is a known limitation (services under active DoS protection connect in Tor Browser ` +
+        `but not here).`
+    );
+  }
 
   // Step 4: Order intro points (by experience if available, otherwise shuffled)
   let introPoints = shuffleInPlace([...descriptor.introPoints]);

--- a/packages/tor/src/hidden-service.ts
+++ b/packages/tor/src/hidden-service.ts
@@ -36,6 +36,15 @@ const S_KEY_LEN = 32; // AES-256 key
 const S_IV_LEN = 16; // AES block/iv length
 
 /**
+ * Default ceiling on the proof-of-work effort the client will attempt, even if
+ * a (signed) descriptor suggests more. Solving cost scales with effort, so an
+ * unbounded suggested-effort from a hostile service could peg the client's CPU
+ * for minutes. Mirrors C Tor's CLIENT_MAX_POW_EFFORT (hs_client.c). Callers can
+ * raise or lower it via HsConnectionOptions.maxPowEffort.
+ */
+const CLIENT_MAX_POW_EFFORT = 10000;
+
+/**
  * Target length for the INTRODUCE1 encrypted section (CLIENT_PK + ciphertext + MAC) per the spec.
  * The spec recommends 490 octets for v3; the relay cell payload limit is RELAY_PAYLOAD_LEN (498),
  * so we cap the encrypted section at (498 - header length) so the full INTRODUCE1 fits in one cell.
@@ -316,7 +325,8 @@ export interface HsConnectionOptions {
   /**
    * Upper bound on the PoW effort to attempt, regardless of the service's
    * suggested effort. Solving cost scales roughly linearly with effort, so this
-   * caps worst-case CPU time. Default: the descriptor's suggested effort.
+   * caps worst-case CPU time. Defaults to CLIENT_MAX_POW_EFFORT (10000, matching
+   * C Tor) so a hostile service's suggested effort can't peg the client's CPU.
    */
   maxPowEffort?: number;
   /**
@@ -2209,12 +2219,23 @@ export async function connectToHiddenServiceCore(
   // it to INTRODUCE1. A request arriving with no PoW token — or too little
   // effort — is deprioritised and, under real load, dropped, surfacing as a
   // RENDEZVOUS2 timeout. See https://spec.torproject.org/hspow-spec.
-  const powRequired =
-    !disablePow && descriptor.powParams !== undefined && descriptor.powParams.suggestedEffort > 0;
-  if (descriptor.powParams && descriptor.powParams.suggestedEffort > 0 && disablePow) {
+  const powAdvertised =
+    descriptor.powParams !== undefined && descriptor.powParams.suggestedEffort > 0;
+  // Only the v1 (Equi-X + Blake2b) scheme is implemented. Matching C Tor
+  // (decode_pow_params skips any non-"v1" type), we ignore unknown/future
+  // schemes rather than sending a bogus POW_SCHEME=1 token the service can't
+  // validate while burning solve time.
+  const powSupported = powAdvertised && descriptor.powParams!.scheme === 'v1';
+  const powRequired = !disablePow && powSupported;
+  if (powAdvertised && !powSupported) {
+    log(
+      `Hidden service requests proof-of-work with unsupported scheme ` +
+        `"${descriptor.powParams!.scheme}"; sending introduction without a PoW token.`
+    );
+  } else if (powAdvertised && disablePow) {
     log(
       `Hidden service requests proof-of-work (suggested-effort=` +
-        `${descriptor.powParams.suggestedEffort}) but PoW is disabled; sending introduction ` +
+        `${descriptor.powParams!.suggestedEffort}) but PoW is disabled; sending introduction ` +
         `without a PoW token (may be dropped by a service enforcing PoW).`
     );
   } else if (powRequired) {
@@ -2265,14 +2286,23 @@ export async function connectToHiddenServiceCore(
   // The observer helper also runs from here so "0 cells received" in the
   // error path means the cell truly never arrived, not that we missed it.
   const rendezvousObserver = rendCircuit.observeRelayTraffic();
-  const rendezvous2Promise = waitForRelayCommand(
-    rendCircuit,
-    RelayCell.RENDEZVOUS2,
-    rendezvousTimeoutMs
-  );
-  // Swallow any unhandled rejection on the promise until we await it below;
-  // the final try/catch in step 7 is what surfaces the failure.
-  rendezvous2Promise.catch(() => {});
+  // Capture RENDEZVOUS2 the instant it arrives (it can beat us on fast
+  // networks), but do NOT start the rendezvous timeout clock here: the
+  // per-attempt proof-of-work solve below can take many seconds, and counting
+  // that against the rendezvous budget would cause spurious timeouts precisely
+  // when PoW is enabled. The timeout is started in step 7, after INTRODUCE1 is
+  // actually sent, so the budget is measured from send time.
+  type RelayEvt = { streamId: number; relayCommand: number; data: Buffer };
+  let rendezvous2Resolve: ((evt: RelayEvt) => void) | undefined;
+  const rendezvous2Latch = new Promise<RelayEvt>((resolve) => {
+    rendezvous2Resolve = resolve;
+  });
+  const onRendezvous2 = (evt: RelayEvt): void => {
+    if (evt.relayCommand !== RelayCell.RENDEZVOUS2) return;
+    rendCircuit.off('relay', onRendezvous2);
+    rendezvous2Resolve?.(evt);
+  };
+  rendCircuit.on('relay', onRendezvous2);
 
   // Step 6: Try intro points until one succeeds
   const introErrors: Error[] = [];
@@ -2294,10 +2324,10 @@ export async function connectToHiddenServiceCore(
       // to another intro point is never rejected as a replay by the service).
       let proofOfWork: BuildIntroduce1Params['proofOfWork'] | undefined;
       if (powRequired && descriptor.powParams) {
-        const effort =
-          maxPowEffort !== undefined
-            ? Math.min(descriptor.powParams.suggestedEffort, maxPowEffort)
-            : descriptor.powParams.suggestedEffort;
+        // Clamp the (signed but service-controlled) suggested effort to a
+        // ceiling so a hostile service can't force unbounded client CPU.
+        const effortCap = maxPowEffort ?? CLIENT_MAX_POW_EFFORT;
+        const effort = Math.min(descriptor.powParams.suggestedEffort, effortCap);
         const powStart = Date.now();
         log(`Solving proof-of-work (effort=${effort})...`);
         const solved = await solveHsPow({
@@ -2406,9 +2436,22 @@ export async function connectToHiddenServiceCore(
     // Use a dedicated rendezvous timeout (default 60s) rather than the overall timeout.
     // If the hidden service received our introduction, it should respond within this window.
     log(`Waiting for rendezvous completion (timeout: ${rendezvousTimeoutMs}ms)...`);
-    let r2: { streamId: number; relayCommand: number; data: Buffer };
+    let r2: RelayEvt;
+    // Start the rendezvous timeout HERE (after INTRODUCE1 was sent), so time
+    // spent solving proof-of-work is not charged against the rendezvous budget.
+    // The listener was already armed (step 6a) so an ultra-fast reply that
+    // arrived during solving is captured in rendezvous2Latch and returns at once.
+    let rendezvousTimer: ReturnType<typeof setTimeout> | undefined;
     try {
-      r2 = await rendezvous2Promise;
+      r2 = await Promise.race([
+        rendezvous2Latch,
+        new Promise<never>((_resolve, reject) => {
+          rendezvousTimer = setTimeout(
+            () => reject(new Error(`Timed out waiting for relayCommand=${RelayCell.RENDEZVOUS2}`)),
+            rendezvousTimeoutMs
+          );
+        }),
+      ]);
     } catch (err) {
       const observed = rendezvousObserver.snapshot();
       rendCircuit.destroy();
@@ -2421,6 +2464,8 @@ export async function connectToHiddenServiceCore(
           `${observed.totalCells} (${observed.commandSummary || 'none'}). ` +
           `Original error: ${msg}`
       );
+    } finally {
+      if (rendezvousTimer) clearTimeout(rendezvousTimer);
     }
     if (r2.data.length < 64) {
       rendCircuit.destroy();
@@ -2437,6 +2482,7 @@ export async function connectToHiddenServiceCore(
 
     return { circuit: rendCircuit, descriptor };
   } finally {
+    rendCircuit.off('relay', onRendezvous2);
     rendezvousObserver.detach();
   }
 }


### PR DESCRIPTION
## Summary

Diagnosis and fix for hidden-service connection failures, focused on the **Tamanegi browser app** against onions that work in Tor Browser. Includes the previously-missing **proof-of-work client** (the main reason DoS-protected onions fail here but not in Tor Browser), the correctness/robustness fixes from the diagnosis, and a way to pull **full debug logs** out of the service-worker-hosted Tor client.

Both live chutney integration paths (client → C-Tor onion, and our host ← our client) pass end-to-end.

## Proof-of-work (proposal 327 / hspow-spec v1: Equi-X + Blake2b)

Services under DoS defense advertise `pow-params` and prioritise their rendezvous queue by client PoW effort; an introduction with no/low effort is dropped → RENDEZVOUS2 timeout. Tor Browser solves the puzzle; we previously didn&#39;t. Now implemented, **all cryptography in `tor-crypto`**:

- `packages/crypto/src/pow/hashx.ts` — HashX keyed hash-program generator + interpreter (faithful port of `tevador/hashx`, the code C Tor vendors as `src/ext/equix/hashx`).
- `packages/crypto/src/pow/equix.ts` — Equi-X (Equihash-60/3 over HashX) Wagner&#39;s-algorithm solver + verifier (port of `tevador/equix`).
- `packages/crypto/src/pow/hspow.ts` — hspow-spec v1 client: builds `P||ID||C||N||htonl(E)`, solves at a chosen effort, validates `R*E &lt;= UINT32_MAX`. **Async and cooperative** (yields between nonce attempts so it never freezes the browser service worker); honours a wall-clock budget.
- `blake2b` added to `hashes.ts` and exposed via `tor-crypto`; the PoW API is re-exported from both `node.ts` and `browser.ts`.

Validated byte-for-byte against the reference implementations and C Tor: HashX digest vectors, a golden Equi-X `challenge → 6 ordered solutions` vector from the reference solver, and C Tor&#39;s `hs_pow.c` verification vectors (zero/high effort, real keys, corrupted-nonce rejection, and a structurally-valid solution that misses the effort target). See `packages/crypto/src/pow/pow.test.ts`.

**Wiring** (`hidden-service.ts`): `connectToHiddenServiceCore` solves the PoW per introduction attempt when the descriptor advertises `pow-params` (fresh nonce per attempt, so a retry is never a replay) and attaches it to INTRODUCE1. New options: `disablePow`, `maxPowEffort`, `powTimeoutMs`. Client-requested effort is clamped to a `CLIENT_MAX_POW_EFFORT` ceiling so a malicious/misconfigured descriptor can&#39;t pin the solver on an unbounded puzzle.

_Known limitation:_ the BigInt solver is correct but CPU-heavy (~3 s per nonce), so very high efforts are slow in pure JS. A lane-based interpreter or WASM is a future optimization; correctness and interop are in place.

## Other fixes

- **`hidden-service.ts`** — consensus param `hsdir-interval` → `hsdir_interval` (real Tor uses underscores; latent wrong-time-period bug).
- **`hidden-service.ts`** — the RENDEZVOUS2 wait is now armed as a listener *before* the introduction loop but the timeout clock only starts *after* INTRODUCE1 is sent, so slow PoW solving is no longer charged against the rendezvous budget (was a spurious timeout under high effort).
- **`browser/client.ts`** &amp; **`build-circuit/node-client.ts`** — `buildCircuitToTarget` now honors `avoid`; browser also excludes the Snowflake entry and requires `Fast`/`Stable` for the middle hop (old empty-flags selection could reuse the rendezvous point and silently drop the introduction).
- **`circuit.ts`** — explicit no-op cases for server-side HS relay commands so a hosting circuit no longer logs spurious `unknown relay message type` errors.

## Debug logging for Tamanegi

The Tor client runs in a service worker (console hard to reach) and verbose HS diagnostics were gated behind the Node-only `TOR_TS_HS_DEBUG` env var.

- `isHsDebugEnabled()` is now per-call and also honors a browser-toggleable `globalThis.__TOR_TS_HS_DEBUG__`; `browser/client.ts` gains a `debug` option that flips it (symmetrically — an explicit `debug: false` turns it back off).
- Tamanegi&#39;s service worker tees status/error/fetch lines into a timestamped ring buffer (`getLogs`), connects with `debug: true`, and the UI has a **&#34;Download debug log&#34;** button exporting the full SRV / time-period / HSDir-ring / per-intro-point / PoW trace for analysis. The export carries no key material.

## Testing

- `tor-crypto`: 72 passing (+15 PoW); node and browser export the same crypto surface (api-surface test).
- `tor`: 424 passing. Typecheck + eslint clean across `tor`, `browser`, and the Tamanegi example.
- Live chutney `hidden-service` and `hidden-service-host` integration paths pass; the previously spurious `unknown relay message type` log errors are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162wa9wM65iw74Cuq1ADfXX