### PR TITLE
fix(tor,tamanegi): HS connect hang at intro attempts + empty debug log export

### DIFF
--- a/examples/tamanegi-browser/src/idb-cache.ts
+++ b/examples/tamanegi-browser/src/idb-cache.ts
@@ -6,10 +6,12 @@
 import type { CachedMicrodesc } from 'browser';
 
 const DB_NAME = 'tor-cache';
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 const CONSENSUS_STORE = 'consensus';
 const MICRODESCS_STORE = 'microdescs';
+const DEBUG_LOG_STORE = 'debuglog';
 const CONSENSUS_KEY = 'current';
+const DEBUG_LOG_KEY = 'current';
 
 // Serializable shape for CachedMicrodesc (Buffers as base64 strings)
 type StoredMicrodesc = {
@@ -33,6 +35,9 @@ function openDB(): Promise<IDBDatabase> {
       }
       if (!db.objectStoreNames.contains(MICRODESCS_STORE)) {
         db.createObjectStore(MICRODESCS_STORE, { keyPath: null });
+      }
+      if (!db.objectStoreNames.contains(DEBUG_LOG_STORE)) {
+        db.createObjectStore(DEBUG_LOG_STORE);
       }
     };
   });
@@ -108,6 +113,57 @@ export const consensusIDB = {
 // ---------------------------------------------------------------------------
 // Microdescriptors
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Debug log
+// ---------------------------------------------------------------------------
+//
+// The service worker's debug-log ring buffer is in-memory, and the browser is
+// free to kill an idle SW at any time — which is exactly the failure mode the
+// log exists to diagnose. Persisting it means a freshly restarted SW can still
+// hand the page the history from the instance that died.
+
+export const debugLogIDB = {
+  async load(): Promise<string[]> {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(DEBUG_LOG_STORE, 'readonly');
+      const req = tx.objectStore(DEBUG_LOG_STORE).get(DEBUG_LOG_KEY);
+      req.onerror = () => reject(req.error);
+      req.onsuccess = () => {
+        db.close();
+        const value = req.result as unknown;
+        resolve(Array.isArray(value) ? (value as string[]) : []);
+      };
+    });
+  },
+
+  async save(entries: string[]): Promise<void> {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(DEBUG_LOG_STORE, 'readwrite');
+      tx.objectStore(DEBUG_LOG_STORE).put(entries, DEBUG_LOG_KEY);
+      tx.oncomplete = () => {
+        db.close();
+        resolve();
+      };
+      tx.onerror = () => reject(tx.error);
+    });
+  },
+
+  async clear(): Promise<void> {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(DEBUG_LOG_STORE, 'readwrite');
+      tx.objectStore(DEBUG_LOG_STORE).clear();
+      tx.oncomplete = () => {
+        db.close();
+        resolve();
+      };
+      tx.onerror = () => reject(tx.error);
+    });
+  },
+};
 
 export const microdescIDB = {
   async loadAll(): Promise<Map<string, CachedMicrodesc>> {

--- a/examples/tamanegi-browser/src/main.ts
+++ b/examples/tamanegi-browser/src/main.ts
@@ -1048,6 +1048,13 @@ async function downloadDebugLog(): Promise<void> {
     a.remove();
     URL.revokeObjectURL(url);
     log(`Debug log exported (${entries.length} entries)`, 'success');
+    if (entries.length === 0) {
+      log(
+        'Debug log came back empty: the service worker that held the logs was likely ' +
+          'terminated by the browser and a fresh instance answered.',
+        'error'
+      );
+    }
   } catch (err) {
     log(`Failed to export debug log: ${err instanceof Error ? err.message : String(err)}`, 'error');
   } finally {
@@ -1164,6 +1171,28 @@ async function initServiceWorker(): Promise<void> {
     log(`Error: ${error}`, 'error');
     setStatus('error', 'Error');
   };
+  swClient.onSwRestarted = () => {
+    // The browser killed the SW that held the Tor client. Reset the UI so the
+    // page doesn't sit on "connecting" forever; the next browse reconnects.
+    if (!connectedPromise && !isConnecting) return;
+    connectedPromise = null;
+    connectedResolve = null;
+    setLoading(false);
+    resetCircuitVisualization();
+    setStatus('disconnected', 'Disconnected');
+    log(
+      'Tor service worker was restarted by the browser; connection lost. Retry to reconnect.',
+      'error'
+    );
+  };
+
+  // Keepalive: the Tor client lives in the service worker, and browsers
+  // terminate service workers that receive no events for ~30s. Ping while a
+  // connection exists (or is being established) so the client survives long
+  // silent stretches such as hidden-service intro attempts.
+  setInterval(() => {
+    if (connectedPromise) swClient?.ping();
+  }, 20_000);
 }
 
 void initServiceWorker();

--- a/examples/tamanegi-browser/src/sw-messages.ts
+++ b/examples/tamanegi-browser/src/sw-messages.ts
@@ -22,7 +22,13 @@ export type MainToSW =
   | { type: 'destroy' }
   | { type: 'getState' }
   /** Request the full captured debug-log buffer (for download / analysis). */
-  | { type: 'getLogs' };
+  | { type: 'getLogs' }
+  /**
+   * Keepalive. Browsers terminate idle service workers after ~30s; the Tor
+   * client (and its Snowflake channel) lives in the SW, so the page pings
+   * while connecting/connected to keep it alive.
+   */
+  | { type: 'ping' };
 
 // ---------------------------------------------------------------------------
 // Service worker -> Main page
@@ -51,4 +57,12 @@ export type SWToMain =
   | { type: 'error'; error: string }
   | { type: 'state'; state: 'idle' | 'connecting' | 'connected' | 'disconnected' }
   /** Full captured debug-log buffer, in response to a `getLogs` request. */
-  | { type: 'logs'; entries: string[] };
+  | { type: 'logs'; entries: string[] }
+  /** Reply to a `ping` keepalive. */
+  | { type: 'pong' }
+  /**
+   * Sent when a service worker instance starts up. If the page had a live
+   * connection or in-flight fetches, receiving this means the previous SW
+   * instance (and the Tor client in it) was killed by the browser.
+   */
+  | { type: 'swStarted' };

--- a/examples/tamanegi-browser/src/sw.ts
+++ b/examples/tamanegi-browser/src/sw.ts
@@ -9,7 +9,7 @@ declare const self: ServiceWorkerGlobalScope;
 import { makeBrowserTorClient } from 'browser';
 import type { BrowserTorClient, CachedMicrodesc, MicrodescStorage } from 'browser';
 import { type MainToSW, type SWToMain, TOR_PROXY_PATH_SEGMENT } from './sw-messages.ts';
-import { consensusIDB, microdescIDB } from './idb-cache.ts';
+import { consensusIDB, debugLogIDB, microdescIDB } from './idb-cache.ts';
 
 // ---------------------------------------------------------------------------
 // State
@@ -29,7 +29,21 @@ let client: BrowserTorClient | null = null;
 // `debug: true` to the browser client on connect, so they land here too.
 
 const MAX_LOG_ENTRIES = 10_000;
-const logBuffer: string[] = [];
+let logBuffer: string[] = [];
+let logFlushTimer: ReturnType<typeof setTimeout> | undefined;
+
+/**
+ * Persist the buffer to IndexedDB (debounced). The buffer alone dies with the
+ * SW instance — and the browser killing the SW is precisely the event we most
+ * need the log to survive.
+ */
+function scheduleLogFlush(): void {
+  if (logFlushTimer !== undefined) return;
+  logFlushTimer = setTimeout(() => {
+    logFlushTimer = undefined;
+    debugLogIDB.save([...logBuffer]).catch(() => {});
+  }, 1000);
+}
 
 function captureLog(line: string): void {
   const ts = new Date().toISOString();
@@ -37,7 +51,25 @@ function captureLog(line: string): void {
   if (logBuffer.length > MAX_LOG_ENTRIES) {
     logBuffer.splice(0, logBuffer.length - MAX_LOG_ENTRIES);
   }
+  scheduleLogFlush();
 }
+
+// Restore the log persisted by any previous SW instance, so an exported log
+// includes history from before a restart instead of coming back empty.
+const logsRestored: Promise<void> = debugLogIDB
+  .load()
+  .then((persisted) => {
+    if (persisted.length > 0) {
+      logBuffer = [...persisted, ...logBuffer].slice(-MAX_LOG_ENTRIES);
+    }
+  })
+  .catch(() => {});
+
+// Startup marker: a restart mid-session means the browser killed the previous
+// instance (taking the Tor client with it) — make that visible in the log and
+// tell any open pages so they can reset instead of waiting forever.
+captureLog('[sw] service worker instance started');
+void broadcast({ type: 'swStarted' });
 
 /**
  * Full proxy path prefix derived from the SW scope so it works under any
@@ -290,9 +322,11 @@ function handleGetState(): void {
   void broadcast({ type: 'state', state });
 }
 
-function handleGetLogs(): void {
-  // Snapshot the buffer so the page gets a stable copy.
-  void broadcast({ type: 'logs', entries: [...logBuffer] });
+async function handleGetLogs(): Promise<void> {
+  // Make sure any log persisted by a previous SW instance has been merged in
+  // before answering, then snapshot the buffer so the page gets a stable copy.
+  await logsRestored;
+  await broadcast({ type: 'logs', entries: [...logBuffer] });
 }
 
 // ---------------------------------------------------------------------------
@@ -350,21 +384,27 @@ self.addEventListener('message', (e: ExtendableMessageEvent) => {
   if (!msg || typeof msg !== 'object' || !('type' in msg)) return;
 
   try {
+    // Long-running work goes through e.waitUntil: without it the handler
+    // returns immediately and the browser is free to terminate the SW ~30s
+    // later, killing the Tor client mid-connect/fetch (the page then hangs on
+    // a reply that will never come, and the in-memory log dies with us).
     switch (msg.type) {
       case 'connect':
-        void handleConnect(msg.options);
+        e.waitUntil(handleConnect(msg.options));
         break;
       case 'fetch':
-        void handleFetch(msg.requestId, msg.url, msg.timeout);
+        e.waitUntil(handleFetch(msg.requestId, msg.url, msg.timeout));
         break;
       case 'refreshConsensus':
         if (client) {
-          client.refreshConsensus().catch((err) => {
-            broadcast({
-              type: 'error',
-              error: err instanceof Error ? err.message : String(err),
-            });
-          });
+          e.waitUntil(
+            client.refreshConsensus().catch((err) => {
+              return broadcast({
+                type: 'error',
+                error: err instanceof Error ? err.message : String(err),
+              });
+            })
+          );
         }
         break;
       case 'destroy':
@@ -374,7 +414,11 @@ self.addEventListener('message', (e: ExtendableMessageEvent) => {
         void handleGetState();
         break;
       case 'getLogs':
-        handleGetLogs();
+        e.waitUntil(handleGetLogs());
+        break;
+      case 'ping':
+        // Keepalive from the page: the event itself resets the SW idle timer.
+        e.waitUntil(broadcast({ type: 'pong' }));
         break;
       default:
         break;

--- a/examples/tamanegi-browser/src/tor-sw-client.ts
+++ b/examples/tamanegi-browser/src/tor-sw-client.ts
@@ -89,8 +89,28 @@ export class TorServiceWorkerClient {
         }
         break;
       }
+      case 'pong':
+        // Keepalive reply; nothing to do.
+        break;
+      case 'swStarted':
+        // A fresh SW instance started. Any Tor client and in-flight requests
+        // in the previous instance are gone — fail them now instead of
+        // leaving their promises (and the UI) hanging forever.
+        if (this.pendingFetch.size > 0) {
+          this.failAllPendingFetches('Tor service worker restarted; connection lost');
+        }
+        this.onSwRestarted?.();
+        break;
       default:
         break;
+    }
+  }
+
+  private failAllPendingFetches(reason: string): void {
+    const pending = [...this.pendingFetch.values()];
+    this.pendingFetch.clear();
+    for (const { reject } of pending) {
+      reject(new Error(reason));
     }
   }
 
@@ -122,7 +142,26 @@ export class TorServiceWorkerClient {
   fetch(url: string, opts?: { timeout?: number }): Promise<FetchResult> {
     return new Promise((resolve, reject) => {
       const requestId = crypto.randomUUID();
-      this.pendingFetch.set(requestId, { resolve, reject });
+      // Watchdog: the real timeout runs inside the SW, but if the browser
+      // kills the SW mid-request the reply never arrives at all. Give the SW
+      // its full budget plus a grace period, then fail the promise so the UI
+      // can't hang indefinitely.
+      const watchdogMs = (opts?.timeout ?? 120_000) + 30_000;
+      const timer = setTimeout(() => {
+        if (this.pendingFetch.delete(requestId)) {
+          reject(new Error(`No response from Tor service worker after ${watchdogMs}ms`));
+        }
+      }, watchdogMs);
+      this.pendingFetch.set(requestId, {
+        resolve: (r) => {
+          clearTimeout(timer);
+          resolve(r);
+        },
+        reject: (err) => {
+          clearTimeout(timer);
+          reject(err);
+        },
+      });
       this.post({
         type: 'fetch',
         requestId,
@@ -130,6 +169,14 @@ export class TorServiceWorkerClient {
         ...(opts?.timeout !== undefined ? { timeout: opts.timeout } : {}),
       });
     });
+  }
+
+  /**
+   * Keepalive ping. Browsers terminate idle service workers after ~30s; each
+   * ping is an event that resets that timer, keeping the Tor client alive.
+   */
+  ping(): void {
+    this.post({ type: 'ping' });
   }
 
   refreshConsensus(): void {
@@ -141,10 +188,7 @@ export class TorServiceWorkerClient {
       navigator.serviceWorker.removeEventListener('message', this.messageHandler);
     }
     this.post({ type: 'destroy' });
-    for (const [, { reject }] of this.pendingFetch) {
-      reject(new Error('Tor client destroyed'));
-    }
-    this.pendingFetch.clear();
+    this.failAllPendingFetches('Tor client destroyed');
     for (const resolve of this.pendingLogs.splice(0)) {
       resolve([]);
     }
@@ -163,4 +207,6 @@ export class TorServiceWorkerClient {
   onConnected?: () => void;
   onDisconnected?: (reason: string) => void;
   onError?: (error: string) => void;
+  /** Called when a new SW instance starts while this page is open (i.e. the previous one was killed). */
+  onSwRestarted?: () => void;
 }

--- a/packages/tor/src/client.ts
+++ b/packages/tor/src/client.ts
@@ -72,7 +72,11 @@ export type FetchOptions = {
   method?: string;
   /** HTTP headers */
   headers?: Record<string, string>;
-  /** Request timeout in ms */
+  /**
+   * Request timeout in ms. For .onion URLs this also bounds the hidden-service
+   * connection setup (descriptor fetch, introduction, rendezvous), not just
+   * the HTTP response read.
+   */
   timeout?: number;
 };
 
@@ -280,7 +284,14 @@ export class TorClient<TChannel extends ChannelConnection = ChannelConnection> {
         ? 443
         : 80;
 
-    const hs = await this.connectToHiddenService(parsedUrl.hostname, port);
+    // Without this, options.timeout only bounded the HTTP response read and
+    // the connection setup ran on its own (much longer) default budget — a
+    // caller-side 120s fetch could sit in intro attempts for many minutes.
+    const hs = await this.connectToHiddenService(
+      parsedUrl.hostname,
+      port,
+      options?.timeout !== undefined ? { overallTimeoutMs: options.timeout } : {}
+    );
     try {
       return await this.fetchOverCircuitFn(hs.circuit, parsedUrl.href, options);
     } finally {

--- a/packages/tor/src/hidden-service.ts
+++ b/packages/tor/src/hidden-service.ts
@@ -283,7 +283,13 @@ export class IptExperienceTracker {
  * Options for the core hidden service connection flow.
  */
 export interface HsConnectionOptions {
-  /** Overall timeout in milliseconds (default: 120000) */
+  /**
+   * Overall budget for the whole connection flow in milliseconds (default:
+   * 120000). Enforced as a hard deadline: introduction attempts stop and the
+   * rendezvous wait is capped once it is exhausted, so a connection can never
+   * run for maxIntroAttempts × (circuit build + PoW solve + ACK wait) — which
+   * unbounded is tens of minutes — while the caller believes it timed out.
+   */
   overallTimeoutMs?: number;
   /** Timeout per handshake operation (default: min of overallTimeoutMs, 120000) */
   perHandshakeTimeoutMs?: number;
@@ -2020,6 +2026,11 @@ export async function connectToHiddenServiceCore(
   } = options;
   const dlog = makeHsDebugLog(log);
 
+  // Hard deadline for the whole flow. Individual steps already have their own
+  // timeouts, but without a shared deadline the intro-attempt loop alone can
+  // run for maxIntroAttempts × (60s circuit build + PoW solve + ACK wait).
+  const overallDeadline = Date.now() + overallTimeoutMs;
+
   const { consensus, dirClient, microdescManager, buildCircuit } = ctx;
 
   if (!consensus.validAfter) {
@@ -2311,6 +2322,12 @@ export async function connectToHiddenServiceCore(
     | undefined;
 
   for (let attempt = 0; attempt < maxIntroAttempts; attempt++) {
+    if (Date.now() >= overallDeadline) {
+      introErrors.push(
+        new Error(`overall timeout (${overallTimeoutMs}ms) exceeded after ${attempt} attempt(s)`)
+      );
+      break;
+    }
     const intro = introPoints[attempt % introPoints.length]!;
 
     let introCircuit: Circuit | undefined;
@@ -2335,7 +2352,7 @@ export async function connectToHiddenServiceCore(
           blindedId: blindedPublicKey,
           effort,
           randomBytes: randomBytesOpt,
-          timeoutMs: powTimeoutMs,
+          timeoutMs: Math.min(powTimeoutMs, Math.max(1, overallDeadline - Date.now())),
         });
         if (solved) {
           log(`Proof-of-work solved in ${Date.now() - powStart}ms (effort=${solved.effort})`);
@@ -2373,7 +2390,7 @@ export async function connectToHiddenServiceCore(
       const ack = await waitForRelayCommand(
         introCircuit,
         RelayCell.INTRODUCE_ACK,
-        perHandshakeTimeoutMs
+        Math.min(perHandshakeTimeoutMs, Math.max(1, overallDeadline - Date.now()))
       );
       if (ack.data.length < 2) throw new Error('INTRODUCE_ACK too short');
       const status = ack.data.readUInt16BE(0);
@@ -2422,7 +2439,7 @@ export async function connectToHiddenServiceCore(
       }
 
       const errorSummary = introErrors.map((e) => e.message).join('; ');
-      throw new Error(`All ${maxIntroAttempts} introduction attempts failed: ${errorSummary}`);
+      throw new Error(`All ${introErrors.length} introduction attempt(s) failed: ${errorSummary}`);
     }
 
     const { introCircuit, state } = successfulIntro;
@@ -2435,7 +2452,14 @@ export async function connectToHiddenServiceCore(
     // Step 7: Await RENDEZVOUS2 (listener was armed before introduction in 6a).
     // Use a dedicated rendezvous timeout (default 60s) rather than the overall timeout.
     // If the hidden service received our introduction, it should respond within this window.
-    log(`Waiting for rendezvous completion (timeout: ${rendezvousTimeoutMs}ms)...`);
+    // The dedicated rendezvous budget still applies, but never past the
+    // overall deadline — a successful introduction must not extend the total
+    // connection time beyond what the caller asked for.
+    const rendezvousWaitMs = Math.min(
+      rendezvousTimeoutMs,
+      Math.max(1, overallDeadline - Date.now())
+    );
+    log(`Waiting for rendezvous completion (timeout: ${rendezvousWaitMs}ms)...`);
     let r2: RelayEvt;
     // Start the rendezvous timeout HERE (after INTRODUCE1 was sent), so time
     // spent solving proof-of-work is not charged against the rendezvous budget.
@@ -2448,7 +2472,7 @@ export async function connectToHiddenServiceCore(
         new Promise<never>((_resolve, reject) => {
           rendezvousTimer = setTimeout(
             () => reject(new Error(`Timed out waiting for relayCommand=${RelayCell.RENDEZVOUS2}`)),
-            rendezvousTimeoutMs
+            rendezvousWaitMs
           );
         }),
       ]);
@@ -2458,7 +2482,7 @@ export async function connectToHiddenServiceCore(
       const msg = err instanceof Error ? err.message : String(err);
       throw new Error(
         `Rendezvous failed: timed out waiting for hidden service response ` +
-          `(${rendezvousTimeoutMs}ms). The service may be offline, overloaded, ` +
+          `(${rendezvousWaitMs}ms). The service may be offline, overloaded, ` +
           `or unable to decrypt the introduction. ` +
           `Cells received on rendezvous circuit during the wait: ` +
           `${observed.totalCells} (${observed.commandSummary || 'none'}). ` +


### PR DESCRIPTION
# Summary

Investigation of a mainnet `.onion` connection that hung at "attempt 2" with a 0-entry debug log export found two compounding failure modes and fixes both.

## Root causes

**1. Nothing kept the service worker alive.** A 0-entry `getLogs` reply is only possible from a freshly started SW instance — `handleConnect` logs `[connect] starting` before doing anything else. Browsers terminate a SW ~30s after its last event; the Tor client, Snowflake channel, and in-memory log buffer all live in the SW, but message handlers ran without `event.waitUntil` and the page sent no events while awaiting a fetch. The browser reclaimed the SW mid-connect: the page's fetch promise could never settle (UI frozen at the last status line), and the log buffer died with the worker — hence the empty export.

**2. Even with a live SW, HS connection setup was effectively unbounded.** The caller's fetch `timeout` only bounded the HTTP response read, and `connectToHiddenServiceCore`'s `overallTimeoutMs` was never enforced as a deadline. The intro loop could legally run 6 × (60s circuit build + 60s PoW solve + 120s ACK wait) ≈ 24 minutes, which also presents as a hang at "attempt N".

## Changes

### tor package
- Enforce `overallTimeoutMs` as a hard deadline: intro attempts stop at it, PoW solves and INTRODUCE_ACK waits are capped by the remaining budget, and the RENDEZVOUS2 wait can't extend past it.
- `TorClient.fetch` passes `options.timeout` through as the HS connect budget for `.onion` URLs, so the caller's budget bounds the whole request.
- Intro-failure summary reports the actual number of attempts made.

### tamanegi-browser example
- connect/fetch/getLogs run under `event.waitUntil`, and the page pings the SW every 20s while connecting/connected, so the browser keeps the worker alive.
- Debug log is persisted to IndexedDB (debounced) and restored on SW startup, with a `[sw] service worker instance started` marker — an export after a crash now contains the pre-crash history instead of coming back empty.
- A fresh SW broadcasts `swStarted`; the page rejects in-flight fetches, resets the UI, and reports the lost connection instead of hanging.
- Page-side watchdog on `swClient.fetch` (SW budget + 30s grace) so the UI can never wait indefinitely on a reply from a dead SW.

## Testing
- `yarn workspace tor test` — 424 passed
- `yarn workspace tor-crypto test` — 72 passed (Node suite)
- `yarn workspace tor typecheck` / `tamanegi-browser` / `browser` — clean; `yarn lint` and `yarn format:check` clean
- Browser-runner vitest suites could not launch in the dev environment (missing Playwright headless-shell binary; fails identically on the clean tree). Worth a real-browser retest against the onionhome URL — the debug log export should now show where attempt 2 spends its time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAD8nJUgcrzsH8mUULvS7u

---
_Generated by [Claude Code](https://claude.ai/code/session_01EAD8nJUgcrzsH8mUULvS7u)_